### PR TITLE
Fix: Use client.aio.chats.create for async chat sessions

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,7 +93,7 @@ async def main_loop():
         "You cannot see the screen or the project explorer, so rely on the tool outputs for information."
     )
     # Create chat session using client.aio.chats.create
-    chat_session = await client.chats.create( # III.2. Rename chat to chat_session
+    chat_session = await client.aio.chats.create( # III.2. Rename chat to chat_session
         model=model_resource_name,
         history=[
             types.Content(role="user", parts=[types.Part(text=system_instruction_text)]),


### PR DESCRIPTION
The Google Generative AI SDK was updated, and the previous client.chats.create method is synchronous. Your code was attempting to await this synchronous call, leading to a TypeError.

This commit updates the chat session creation in `main.py` to use `client.aio.chats.create` as required by the new SDK's asynchronous operations. This aligns with the SDK's migration guide and ensures that an awaitable coroutine is used, resolving the TypeError.

I also verified `requirements.txt` to ensure it uses the correct `google-genai` package.