### PR TITLE
Fix: Correctly initialize async chat session

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,7 +93,7 @@ async def main_loop():
         "You cannot see the screen or the project explorer, so rely on the tool outputs for information."
     )
     # Create chat session using client.aio.chats.create
-    chat_session = await client.chats.create( # III.2. Rename chat to chat_session
+    chat_session = client.aio.chats.create( # III.2. Rename chat to chat_session
         model=model_resource_name,
         history=[
             types.Content(role="user", parts=[types.Part(text=system_instruction_text)]),


### PR DESCRIPTION
The previous attempt to fix the TypeError by adding .aio to client.chats.create and awaiting it was still incorrect, leading to `TypeError: object AsyncChat can't be used in 'await' expression`.

The `google-genai` SDK documentation shows that `client.aio.chats.create()` is a synchronous method that returns an `AsyncChat` object. The methods on this `AsyncChat` object are then awaitable (e.g., `await chat.send_message()`).

This commit removes the `await` from the `client.aio.chats.create()` call in `main.py` to correctly initialize the async chat session.