### PR TITLE
Fix: Correct HTML formatting for prompt_text

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,7 +140,7 @@ async def main_loop():
 
             user_input_str = ""
             try:
-                prompt_text = HTML('<ansiblue bold>You: </ansiblue>')
+                prompt_text = HTML('<ansiblue><b>You: </b></ansiblue>')
                 user_input_str = await asyncio.to_thread(session.prompt, prompt_text, reserve_space_for_menu=0)
             except KeyboardInterrupt:
                 console.print("\n[bold yellow]Exiting broker...[/bold yellow]")


### PR DESCRIPTION
The previous HTML string '<ansiblue bold>You: </ansiblue>' was causing an xml.parsers.expat.ExpatError because the 'bold' attribute was not correctly associated with a value or nested as a tag.

This change corrects the formatting to '<ansiblue><b>You: </b></ansiblue>', nesting the <b> tag within the <ansiblue> tag, which is the proper way to apply multiple styles according to prompt_toolkit's HTML parsing rules. This resolves the startup crash.