### PR TITLE
Fix: Update chat message sending method for new SDK

### DIFF
--- a/main.py
+++ b/main.py
@@ -159,7 +159,7 @@ async def main_loop():
                 # III.3. New message sending and tool response loop
                 # Send initial user message
                 with console.status("[bold green]Gemini is thinking...", spinner="dots") as status_spinner_gemini:
-                    response = await chat_session.send_message_async( # III.2. Use chat_session
+                    response = await chat_session.send_message( # III.2. Use chat_session
                         content=user_input_str,
                         tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE] # Use new tool instance
                     )
@@ -196,7 +196,7 @@ async def main_loop():
                     # Send tool responses back to the model
                     if tool_response_parts:
                         with console.status("[bold green]Gemini is processing tool results...", spinner="dots") as status_spinner_gemini_processing:
-                            response = await chat_session.send_message_async( # III.2. Use chat_session
+                            response = await chat_session.send_message( # III.2. Use chat_session
                                 content=tool_response_parts, # Send list of Part objects
                                 tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE] # Use new tool instance
                             )


### PR DESCRIPTION
Replaced calls to 'chat_session.send_message_async' with 'chat_session.send_message' in main.py.

This change addresses an AttributeError ('AsyncChat' object has no attribute 'send_message_async') that occurred after migrating to a newer version of the google-genai SDK. The new SDK likely uses 'send_message' as the awaitable method for AsyncChatSession instances. This commit assumes the method returns a single response object compatible with the existing response handling logic.