### PR TITLE
Fix: Align JSON-RPC params with Rust server's expected structure

### DIFF
--- a/main.py
+++ b/main.py
@@ -160,10 +160,8 @@ async def main_loop():
                 # Send initial user message
                 with console.status("[bold green]Gemini is thinking...", spinner="dots") as status_spinner_gemini:
                     response = await chat_session.send_message( # III.2. Use chat_session
-
                         message=user_input_str,
                         config=types.GenerateContentConfig(tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE]) # Use new tool instance
-
                     )
 
                 # Inner loop for handling a sequence of function calls
@@ -199,10 +197,8 @@ async def main_loop():
                     if tool_response_parts:
                         with console.status("[bold green]Gemini is processing tool results...", spinner="dots") as status_spinner_gemini_processing:
                             response = await chat_session.send_message( # III.2. Use chat_session
-
                                 message=tool_response_parts, # Send list of Part objects
                                 config=types.GenerateContentConfig(tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE]) # Use new tool instance
-
                             )
                     else:
                         logger.warning("No tool response parts to send, though function calls were expected.")

--- a/mcp_client.py
+++ b/mcp_client.py
@@ -184,7 +184,12 @@ class MCPClient:
             raise MCPConnectionError(err_msg)
 
         request_id = str(uuid.uuid4())
-        request_payload = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+
+        # Convert method to PascalCase for wrapping params
+        pascal_case_method = "".join(word.capitalize() for word in method.split('_'))
+        wrapped_params = {pascal_case_method: params}
+
+        request_payload = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": wrapped_params}
         future = asyncio.Future()
         self.pending_requests[request_id] = future
 


### PR DESCRIPTION
Modified mcp_client.py to wrap the tool parameters within a dictionary keyed by the PascalCase version of the method name. For example, for method "insert_model" with params {"query": "kart"}, the JSON-RPC 'params' field is now structured as:
{"InsertModel": {"query": "kart"}}.

This change addresses the Rust server error:
"serde error data did not match any variant of untagged enum JsonRpcMessage". It ensures the 'params' field correctly deserializes into the server-side 'ToolArgumentValues' Rust enum, which uses PascalCase for its variants (e.g., InsertModel, RunCode).