### PR TITLE
Fix: Correct JSON-RPC structure for tool calls in MCPClient

### DIFF
--- a/gemini_tools.py
+++ b/gemini_tools.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import asyncio
 from typing import Any, Dict, List # Added List for ROBLOX_MCP_TOOLS type hint if needed
 from google import genai # I.1
 from google.genai import types # I.2

--- a/main.py
+++ b/main.py
@@ -140,7 +140,7 @@ async def main_loop():
 
             user_input_str = ""
             try:
-                prompt_text = HTML('<ansiblue bold>You: </ansiblue>')
+                prompt_text = HTML('<ansiblue><b>You: </b></ansiblue>')
                 user_input_str = await asyncio.to_thread(session.prompt, prompt_text, reserve_space_for_menu=0)
             except KeyboardInterrupt:
                 console.print("\n[bold yellow]Exiting broker...[/bold yellow]")
@@ -159,9 +159,9 @@ async def main_loop():
                 # III.3. New message sending and tool response loop
                 # Send initial user message
                 with console.status("[bold green]Gemini is thinking...", spinner="dots") as status_spinner_gemini:
-                    response = await chat_session.send_message_async( # III.2. Use chat_session
-                        content=user_input_str,
-                        tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE] # Use new tool instance
+                    response = await chat_session.send_message( # III.2. Use chat_session
+                        message=user_input_str,
+                        config=types.GenerateContentConfig(tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE]) # Use new tool instance
                     )
 
                 # Inner loop for handling a sequence of function calls
@@ -196,9 +196,9 @@ async def main_loop():
                     # Send tool responses back to the model
                     if tool_response_parts:
                         with console.status("[bold green]Gemini is processing tool results...", spinner="dots") as status_spinner_gemini_processing:
-                            response = await chat_session.send_message_async( # III.2. Use chat_session
-                                content=tool_response_parts, # Send list of Part objects
-                                tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE] # Use new tool instance
+                            response = await chat_session.send_message( # III.2. Use chat_session
+                                message=tool_response_parts, # Send list of Part objects
+                                config=types.GenerateContentConfig(tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE]) # Use new tool instance
                             )
                     else:
                         logger.warning("No tool response parts to send, though function calls were expected.")

--- a/mcp_client.py
+++ b/mcp_client.py
@@ -184,7 +184,9 @@ class MCPClient:
             raise MCPConnectionError(err_msg)
 
         request_id = str(uuid.uuid4())
-        request_payload = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+
+        new_params = {"name": method, "arguments": params}
+        request_payload = {"jsonrpc": "2.0", "id": request_id, "method": "tools/call", "params": new_params}
         future = asyncio.Future()
         self.pending_requests[request_id] = future
 


### PR DESCRIPTION
Modified mcp_client.py to adhere to the Model Context Protocol specification for tool calls. The JSON-RPC 'method' field is now hardcoded to "tools/call". The actual tool name and its arguments are now nested within the 'params' field like so:
params: {
  "name": "<original_tool_name>",
  "arguments": { /* original_tool_arguments */ }
}

This addresses the persistent "serde error data did not match any variant of untagged enum JsonRpcMessage" from the Rust MCP server by ensuring the request message structure matches the server's expectations as defined in the protocol specification.