### PR TITLE
Feat: Implement MCP initialization handshake in Python client

### DIFF
--- a/gemini_tools.py
+++ b/gemini_tools.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import asyncio
 from typing import Any, Dict, List # Added List for ROBLOX_MCP_TOOLS type hint if needed
 from google import genai # I.1
 from google.genai import types # I.2

--- a/main.py
+++ b/main.py
@@ -140,7 +140,7 @@ async def main_loop():
 
             user_input_str = ""
             try:
-                prompt_text = HTML('<ansiblue bold>You: </ansiblue>')
+                prompt_text = HTML('<ansiblue><b>You: </b></ansiblue>')
                 user_input_str = await asyncio.to_thread(session.prompt, prompt_text, reserve_space_for_menu=0)
             except KeyboardInterrupt:
                 console.print("\n[bold yellow]Exiting broker...[/bold yellow]")
@@ -159,9 +159,9 @@ async def main_loop():
                 # III.3. New message sending and tool response loop
                 # Send initial user message
                 with console.status("[bold green]Gemini is thinking...", spinner="dots") as status_spinner_gemini:
-                    response = await chat_session.send_message_async( # III.2. Use chat_session
-                        content=user_input_str,
-                        tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE] # Use new tool instance
+                    response = await chat_session.send_message( # III.2. Use chat_session
+                        message=user_input_str,
+                        config=types.GenerateContentConfig(tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE]) # Use new tool instance
                     )
 
                 # Inner loop for handling a sequence of function calls
@@ -196,9 +196,9 @@ async def main_loop():
                     # Send tool responses back to the model
                     if tool_response_parts:
                         with console.status("[bold green]Gemini is processing tool results...", spinner="dots") as status_spinner_gemini_processing:
-                            response = await chat_session.send_message_async( # III.2. Use chat_session
-                                content=tool_response_parts, # Send list of Part objects
-                                tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE] # Use new tool instance
+                            response = await chat_session.send_message( # III.2. Use chat_session
+                                message=tool_response_parts, # Send list of Part objects
+                                config=types.GenerateContentConfig(tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE]) # Use new tool instance
                             )
                     else:
                         logger.warning("No tool response parts to send, though function calls were expected.")

--- a/mcp_client.py
+++ b/mcp_client.py
@@ -63,6 +63,56 @@ class MCPClient:
             await self._cleanup_process_resources()
             return False
 
+    async def _perform_initialization_handshake(self) -> None:
+        try:
+            logger.info("Performing MCP initialization handshake...")
+            # Define client capabilities and info
+            client_info = {"name": "RobloxStudioAgentPython", "version": "0.1.0"} # Consider making version dynamic later
+            # Based on MCP spec, ClientCapabilities can be simple for now.
+            # Example: roots and sampling are objects if present.
+            client_capabilities = {
+                "roots": {}, # Indicates support for roots, can be empty object
+                "sampling": {} # Indicates support for sampling, can be empty object
+            }
+            initialize_params = {
+                "protocolVersion": "2024-11-05", # From user-provided spec
+                "capabilities": client_capabilities,
+                "clientInfo": client_info
+            }
+
+            logger.info(f"Sending initialize request with params: {initialize_params}")
+            init_response = await self.send_request("initialize", initialize_params, timeout=10.0) # Use a reasonable timeout
+            logger.info(f"Received initialize response: {init_response}")
+
+            if "error" in init_response:
+                error_details = init_response.get("error", {})
+                msg = f"MCP Initialization failed: {error_details.get('message', 'Unknown error')}"
+                logger.error(msg)
+                raise MCPConnectionError(msg)
+
+            # Process InitializeResult (e.g., check protocolVersion, store serverCapabilities if needed)
+            # For now, just log it. Future improvements can make use of server_info, capabilities etc.
+            server_protocol_version = init_response.get("result", {}).get("protocolVersion")
+            if server_protocol_version != "2024-11-05": # Or check for compatibility
+                logger.warning(f"Server proposed protocol version {server_protocol_version}, client uses 2024-11-05. Continuing for now.")
+
+            # Send initialized notification
+            initialized_params = {} # notifications/initialized has no specific params in the provided spec
+            await self.send_notification("notifications/initialized", initialized_params)
+            logger.info("MCP initialization handshake completed successfully.")
+
+        except MCPConnectionError as e:
+            # Re-raise to be handled by the calling context (e.g., start() or reconnect())
+            logger.error(f"MCP handshake failed due to connection error: {e}")
+            raise
+        except asyncio.TimeoutError: # Specifically for the initialize request timeout
+            logger.error("MCP initialize request timed out.")
+            raise MCPConnectionError("MCP initialize request timed out.")
+        except Exception as e:
+            logger.error(f"Unexpected error during MCP handshake: {e}", exc_info=True)
+            # Wrap generic exceptions in MCPConnectionError to signal handshake failure
+            raise MCPConnectionError(f"Unexpected error during MCP handshake: {e}")
+
     async def start(self) -> None:
         """Launches the MCP server process, with retries for initial start."""
         if not self.server_path.exists():
@@ -71,12 +121,18 @@ class MCPClient:
         for attempt in range(self.max_initial_start_attempts):
             logger.info(f"MCP server startup attempt {attempt + 1}/{self.max_initial_start_attempts}...")
             if await self._launch_server_process():
-                logger.info("MCP server started successfully.")
-                return
+                try:
+                    await self._perform_initialization_handshake()
+                    logger.info("MCP server started and initialized successfully.")
+                    return
+                except MCPConnectionError as e: # Handshake specific error
+                    logger.error(f"MCP initialization failed after start: {e}. Will attempt to stop server.")
+                    await self.stop() # Clean up the launched process if handshake fails
+                    # Continue to the next startup attempt if any are left
             if attempt < self.max_initial_start_attempts - 1:
                 await asyncio.sleep(2 + attempt)
-        logger.critical(f"Failed to start MCP server after {self.max_initial_start_attempts} attempts.")
-        raise MCPConnectionError(f"Failed to start MCP server after {self.max_initial_start_attempts} attempts.")
+        logger.critical(f"Failed to start and initialize MCP server after {self.max_initial_start_attempts} attempts.")
+        raise MCPConnectionError(f"Failed to start and initialize MCP server after {self.max_initial_start_attempts} attempts.")
 
     async def _cleanup_process_resources(self):
         """Cleans up resources associated with the server process."""
@@ -116,8 +172,14 @@ class MCPClient:
         for attempt in range(self.reconnect_attempts):
             logger.info(f"Reconnect attempt {attempt + 1}/{self.reconnect_attempts}...")
             if await self._launch_server_process(): # This will set connection_lost to False on success
-                logger.info("MCP server reconnected successfully.")
-                return True # connection_lost is already False
+                try:
+                    await self._perform_initialization_handshake()
+                    logger.info("MCP server reconnected and initialized successfully.")
+                    return True
+                except MCPConnectionError as e:
+                    logger.error(f"MCP initialization failed after reconnect: {e}. Will attempt to stop server.")
+                    await self.stop()
+                    # Fall through to next reconnect attempt or failure
             if attempt < self.reconnect_attempts - 1:
                 await asyncio.sleep(3 + attempt * 2)
 
@@ -214,5 +276,45 @@ class MCPClient:
             err_msg = f"Unexpected error sending request: {e}"
             logger.error(f"Unexpected error sending request {request_id}: {e}", exc_info=True)
             self.connection_lost = True
+            self._clear_pending_requests(MCPConnectionError(err_msg))
+            raise MCPConnectionError(err_msg)
+
+    async def send_notification(self, method: str, params: dict) -> None:
+        if not self.is_alive() or not self.process or not self.process.stdin:
+            self.connection_lost = True
+            err_msg = "MCP server process is not running or stdin is unavailable for notification."
+            logger.error(f"Attempted to send notification but {err_msg.lower()}")
+            # Do not clear pending_requests here as this is a separate path
+            raise MCPConnectionError(err_msg)
+
+        notification_payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params
+        }
+        # Note: No "id" field for notifications
+
+        try:
+            json_message = json.dumps(notification_payload) + "\n"
+            self.process.stdin.write(json_message.encode('utf-8'))
+            await self.process.stdin.drain()
+            logger.info(f"-> Sent MCP notification (Method: {method})")
+        except BrokenPipeError as e:
+            err_msg = f"Connection lost (BrokenPipeError) while sending notification {method}: {e}"
+            logger.error(err_msg)
+            self.connection_lost = True
+            # Clear pending requests as the connection is broken for all operations
+            self._clear_pending_requests(MCPConnectionError(err_msg))
+            raise MCPConnectionError(err_msg)
+        except RuntimeError as e: # Can be raised if stdin is closed
+            err_msg = f"Connection lost (RuntimeError) while sending notification {method}: {e}"
+            logger.error(err_msg)
+            self.connection_lost = True
+            self._clear_pending_requests(MCPConnectionError(err_msg))
+            raise MCPConnectionError(err_msg)
+        except Exception as e:
+            err_msg = f"Unexpected error sending notification {method}: {e}"
+            logger.error(err_msg, exc_info=True)
+            self.connection_lost = True # Assume connection is compromised
             self._clear_pending_requests(MCPConnectionError(err_msg))
             raise MCPConnectionError(err_msg)


### PR DESCRIPTION
I've added the required MCP initialization sequence to mcp_client.py:
- Added `send_notification` method to `MCPClient` for sending JSON-RPC notifications (no ID).
- Implemented `_perform_initialization_handshake` method to:
  1. Send an "initialize" request with client capabilities and protocol version.
  2. Process the "InitializeResult" from the server.
  3. Send a "notifications/initialized" notification.
- Updated `MCPClient.start()` and `MCPClient.reconnect()` to execute this handshake after the server process is launched/restarted.

This change addresses the "ExpectedInitializeRequest" error from the Rust MCP server by ensuring the client follows the specified MCP protocol startup procedure.