### PR TITLE
Fix: Correct MCP initialize request format

### DIFF
--- a/mcp_client.py
+++ b/mcp_client.py
@@ -249,9 +249,9 @@ class MCPClient:
 
         request_id = str(uuid.uuid4())
 
-
-        new_params = {"name": method, "arguments": params}
-        request_payload = {"jsonrpc": "2.0", "id": request_id, "method": "tools/call", "params": new_params}
+        # The 'method' parameter already contains the full method name (e.g., "initialize")
+        # The 'params' parameter directly contains the parameters for the call.
+        request_payload = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
 
         future = asyncio.Future()
         self.pending_requests[request_id] = future


### PR DESCRIPTION
The MCP client was sending the 'initialize' request with the method field hardcoded to 'tools/call' and with its parameters nested under 'name' and 'arguments'. This did not match the expected format by the MCP server, which requires the method to be 'initialize' and parameters to be directly under the 'params' field.

This commit corrects the `send_protocol_request` function in `mcp_client.py` to use the provided method and params directly in the JSON-RPC request payload. This ensures that the 'initialize' request is sent in the correct format as per the MCP specification.