### PR TITLE
I've addressed the `AttributeError: ANY` in the tool definitions.

### DIFF
--- a/gemini_tools.py
+++ b/gemini_tools.py
@@ -140,7 +140,7 @@ ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE = types.Tool(
                     "method_name": types.Schema(type=types.Type.STRING, description="Name of the method to call (e.g., 'MoveTo', 'Destroy', 'SetNetworkOwner')."),
                     "arguments": types.Schema(
                         type=types.Type.ARRAY,
-                        items=types.Schema(type=types.Type.ANY), # Luau side handles type validation of individual args
+                        items=types.Schema(), # Luau side handles type validation of individual args
                         description="List of arguments for the method. Use defined dict/string formats for complex types. Empty list if no arguments. E.g., [{'x':10,'y':0,'z':5}] for MoveTo, or [nil] for SetNetworkOwner(nil)."
                     )
                 },
@@ -196,7 +196,7 @@ ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE = types.Tool(
                 type=types.Type.OBJECT,
                 properties={
                     "property_name": types.Schema(type=types.Type.STRING, description="Name of the Lighting service property (e.g., 'Ambient', 'Brightness', 'ClockTime', 'Technology')."),
-                    "value": types.Schema(type=types.Type.ANY, description="New value for the property. Use dicts for Color3/Vector3, string for Enums.")
+                    "value": types.Schema(type=types.Type.STRING, description="New value for the property. Use dicts for Color3/Vector3, string for Enums. Value will be parsed by Luau.")
                 },
                 required=["property_name", "value"]
             )
@@ -235,7 +235,7 @@ ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE = types.Tool(
                 type=types.Type.OBJECT,
                 properties={
                     "property_name": types.Schema(type=types.Type.STRING, description="Name of the Workspace service property (e.g., 'Gravity', 'FilteringEnabled')."),
-                    "value": types.Schema(type=types.Type.ANY, description="New value for the property. Use dicts for Vector3, string for Enums.")
+                    "value": types.Schema(type=types.Type.STRING, description="New value for the property. Use dicts for Vector3, string for Enums. Value will be parsed by Luau.")
                 },
                 required=["property_name", "value"]
             )
@@ -467,7 +467,7 @@ ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE = types.Tool(
                 properties={
                     "store_name": types.Schema(type=types.Type.STRING, description="Name of the DataStore."),
                     "key": types.Schema(type=types.Type.STRING, description="The key to save data under."),
-                    "data": types.Schema(type=types.Type.ANY, description="Data to save (JSON object/array, string, number, or boolean). Complex Lua tables will be JSON encoded by the client; provide as valid JSON structure.")
+                    "data": types.Schema(type=types.Type.STRING, description="Data to save (JSON object/array, string, number, or boolean). Complex Lua tables will be JSON encoded by the client; provide as valid JSON structure. Value will be parsed by Luau.")
                 },
                 required=["store_name", "key", "data"]
             )


### PR DESCRIPTION
It seems the `types.Type.ANY` attribute was causing an issue because it's not a valid member of the `google.genai.types.Type` enum.

Here's what I changed:
- In the `call_instance_method` tool definition, I modified the 'arguments' parameter. Instead of `items=types.Schema(type=types.Type.ANY)`, it's now `items=types.Schema()`. The type validation for this will be handled by Luau.
- I also proactively addressed similar situations in other tool definitions:
    - For `set_lighting_property`, I changed the `value` parameter from `types.Type.ANY` to `types.Type.STRING`.
    - For `set_workspace_property`, I changed the `value` parameter from `types.Type.ANY` to `types.Type.STRING`.
    - For `save_data`, I changed the `data` parameter from `types.Type.ANY` to `types.Type.STRING`. In these cases, `STRING` is used as a general type, and Luau will take care of the specific parsing and validation, just as indicated in the existing comments.

With these adjustments, the main application `main.py` should now start without the `AttributeError: ANY`.