### PR TITLE
Fix: Use INTERNAL_ERROR for tool execution timeouts

### DIFF
--- a/src/rbx_studio_server.rs
+++ b/src/rbx_studio_server.rs
@@ -322,7 +322,7 @@ impl RBXStudioServer {
                 }
 
 
-                Err(McpError::new(rmcp::model::ErrorCode::Error, format!("Tool execution timed out after {}s.", TOOL_EXECUTION_TIMEOUT.as_secs()), None))
+                Err(McpError::new(rmcp::model::ErrorCode::INTERNAL_ERROR, format!("Tool execution timed out after {}s.", TOOL_EXECUTION_TIMEOUT.as_secs()), None))
 
 
             }


### PR DESCRIPTION
The previous code used `rmcp::model::ErrorCode::Error`, which does not exist in the `rmcp` crate. This commit changes it to use `rmcp::model::ErrorCode::INTERNAL_ERROR` instead, which is a more appropriate error code for this situation.