### PR TITLE
Fix compilation errors in rbx_studio_server.rs

### DIFF
--- a/src/rbx_studio_server.rs
+++ b/src/rbx_studio_server.rs
@@ -5,11 +5,13 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{extract::State, Json};
 // color_eyre is not directly used, McpError handles errors.
+use rmcp::handler::server::tool::Parameters;
 use rmcp::model::{
     ServerCapabilities, ServerInfo, ProtocolVersion, Implementation, Content, CallToolResult, ToolsCapability,
 };
 use rmcp::schemars;
 use rmcp::tool;
+use rmcp::tool::Schema;
 use rmcp::{Error as McpError, ServerHandler};
 
 use std::collections::{HashMap, VecDeque};
@@ -358,19 +360,18 @@ impl ServerHandler for RBXStudioServer {
             props.insert("tool_arguments_str".to_string(), rmcp::serde_json::json!({"type": "string", "description": "A JSON string representing arguments for the Luau tool."}));
             props
         };
-        let exec_tool_params = rmcp::model::Parameters {
+        let exec_tool_params = Parameters {
             r#type: "object".to_string(),
             properties: exec_tool_params_props,
             required: vec!["tool_name".to_string(), "tool_arguments_str".to_string()],
         };
         let exec_tool = rmcp::model::Tool {
-            name: "execute_discovered_luau_tool".to_string(),
+            name: "execute_discovered_luau_tool".to_string().into(),
             description: Some(format!(
                 "Executes a specific Luau tool script by its name. Available Luau tools: [{}]",
                 self.discovered_luau_tools.keys().cloned().collect::<Vec<String>>().join(", ")
-            )),
-            inputs: Some(rmcp::model::Schema::Object(exec_tool_params)),
-            outputs: None,
+            ).into()),
+            input_schema: Some(Schema::Object(exec_tool_params)),
         };
         tools_list.push(exec_tool);
 
@@ -380,16 +381,15 @@ impl ServerHandler for RBXStudioServer {
             props.insert("command".to_string(), rmcp::serde_json::json!({"type": "string", "description": "The Luau code to execute."}));
             props
         };
-        let run_cmd_params = rmcp::model::Parameters {
+        let run_cmd_params = Parameters {
             r#type: "object".to_string(),
             properties: run_cmd_params_props,
             required: vec!["command".to_string()],
         };
         let run_cmd_tool = rmcp::model::Tool {
-            name: "run_command".to_string(),
-            description: Some("Runs a raw Luau command string in Roblox Studio.".to_string()),
-            inputs: Some(rmcp::model::Schema::Object(run_cmd_params)),
-            outputs: None,
+            name: "run_command".to_string().into(),
+            description: Some("Runs a raw Luau command string in Roblox Studio.".to_string().into()),
+            input_schema: Some(Schema::Object(run_cmd_params)),
         };
         tools_list.push(run_cmd_tool);
 
@@ -399,22 +399,21 @@ impl ServerHandler for RBXStudioServer {
             props.insert("query".to_string(), rmcp::serde_json::json!({"type": "string", "description": "Query to search for the model."}));
             props
         };
-        let insert_model_params = rmcp::model::Parameters {
+        let insert_model_params = Parameters {
             r#type: "object".to_string(),
             properties: insert_model_params_props,
             required: vec!["query".to_string()],
         };
         let insert_model_tool = rmcp::model::Tool {
-            name: "insert_model".to_string(),
-            description: Some("Inserts a model from the Roblox marketplace into the workspace.".to_string()),
-            inputs: Some(rmcp::model::Schema::Object(insert_model_params)),
-            outputs: None,
+            name: "insert_model".to_string().into(),
+            description: Some("Inserts a model from the Roblox marketplace into the workspace.".to_string().into()),
+            input_schema: Some(Schema::Object(insert_model_params)),
         };
         tools_list.push(insert_model_tool);
 
         let mut capabilities = ServerCapabilities::default();
         capabilities.tools = Some(ToolsCapability {
-            tools: tools_list,
+            tool_definitions: tools_list,
             list_changed: Some(true),
             // No other tool capabilities like 'definition_provider' are being set here.
         });
@@ -429,7 +428,7 @@ impl ServerHandler for RBXStudioServer {
             instructions: Some(
                 format!("Use 'execute_discovered_luau_tool' to run discovered Luau scripts by name. Discovered Luau tools: [{}]. Also available: run_command (direct Luau string), insert_model.",
                     self.discovered_luau_tools.keys().cloned().collect::<Vec<String>>().join(", ")
-                )
+                ).into()
             ),
             capabilities,
         }


### PR DESCRIPTION
I've addressed several compilation errors:
- Updated imports for `Parameters` and `Schema` types based on compiler suggestions.
- Corrected `Parameters` usage to `rmcp::handler::server::tool::Parameters`.
- Corrected `Schema` usage to `rmcp::tool::Schema`.
- Added `.into()` conversions for `String` to `Cow<'_, str>` for various fields in `Tool` and `ServerInfo` structs.
- Updated `Tool` struct field names: `inputs` to `input_schema` and removed `outputs`.
- Updated `ToolsCapability` struct: renamed `tools` field to `tool_definitions`.

These changes are based on the compiler error messages and aim to align the code with potential updates in the `rmcp` crate API.