### PR TITLE
Fix compilation errors in rbx_studio_server.rs (Attempt 2)

### DIFF
--- a/src/rbx_studio_server.rs
+++ b/src/rbx_studio_server.rs
@@ -5,8 +5,9 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{extract::State, Json};
 // color_eyre is not directly used, McpError handles errors.
+use rmcp::handler::server::tool::Parameters; // This will likely be unused after refactor
 use rmcp::model::{
-    ServerCapabilities, ServerInfo, ProtocolVersion, Implementation, Content, CallToolResult, ToolsCapability,
+    ServerCapabilities, ServerInfo, ProtocolVersion, Implementation, Content, CallToolResult, ToolsCapability, Schema, SchemaObject,
 };
 use rmcp::schemars;
 use rmcp::tool;
@@ -358,19 +359,46 @@ impl ServerHandler for RBXStudioServer {
             props.insert("tool_arguments_str".to_string(), rmcp::serde_json::json!({"type": "string", "description": "A JSON string representing arguments for the Luau tool."}));
             props
         };
-        let exec_tool_params = rmcp::model::Parameters {
-            r#type: "object".to_string(),
-            properties: exec_tool_params_props,
-            required: vec!["tool_name".to_string(), "tool_arguments_str".to_string()],
+        let exec_tool_schema_object_data = rmcp::model::SchemaObject {
+            properties: exec_tool_params_props.into_iter().map(|(k, v)| (k.into(), Schema::from_json_value(v).unwrap_or_else(|e| panic!("Failed to convert Value to Schema for exec_tool_params_props property {}: {}", k, e)) )).collect(),
+            required: vec!["tool_name".to_string(), "tool_arguments_str".to_string()].into_iter().map(|s| s.into()).collect(),
+            description: None,
+            default_value: None,
+            read_only: false,
+            write_only: false,
+            examples: None,
+            all_of: None,
+            any_of: None,
+            one_of: None,
+            not: None,
+            r#if: None,
+            then: None,
+            r#else: None,
+            format: None,
+            pattern: None,
+            max_length: None,
+            min_length: None,
+            max_items: None,
+            min_items: None,
+            unique_items: false,
+            max_properties: None,
+            min_properties: None,
+            multiple_of: None,
+            maximum: None,
+            exclusive_maximum: None,
+            minimum: None,
+            exclusive_minimum: None,
+            r#enum: None,
+            r#const: None,
         };
         let exec_tool = rmcp::model::Tool {
-            name: "execute_discovered_luau_tool".to_string(),
+            name: "execute_discovered_luau_tool".to_string().into(),
             description: Some(format!(
                 "Executes a specific Luau tool script by its name. Available Luau tools: [{}]",
                 self.discovered_luau_tools.keys().cloned().collect::<Vec<String>>().join(", ")
-            )),
-            inputs: Some(rmcp::model::Schema::Object(exec_tool_params)),
-            outputs: None,
+            ).into()),
+            input_schema: Some(Schema::Object(exec_tool_schema_object_data)),
+            annotations: None,
         };
         tools_list.push(exec_tool);
 
@@ -380,16 +408,43 @@ impl ServerHandler for RBXStudioServer {
             props.insert("command".to_string(), rmcp::serde_json::json!({"type": "string", "description": "The Luau code to execute."}));
             props
         };
-        let run_cmd_params = rmcp::model::Parameters {
-            r#type: "object".to_string(),
-            properties: run_cmd_params_props,
-            required: vec!["command".to_string()],
+        let run_cmd_schema_object_data = rmcp::model::SchemaObject {
+            properties: run_cmd_params_props.into_iter().map(|(k, v)| (k.into(), Schema::from_json_value(v).unwrap_or_else(|e| panic!("Failed to convert Value to Schema for run_cmd_params_props property {}: {}", k, e)) )).collect(),
+            required: vec!["command".to_string()].into_iter().map(|s| s.into()).collect(),
+            description: None,
+            default_value: None,
+            read_only: false,
+            write_only: false,
+            examples: None,
+            all_of: None,
+            any_of: None,
+            one_of: None,
+            not: None,
+            r#if: None,
+            then: None,
+            r#else: None,
+            format: None,
+            pattern: None,
+            max_length: None,
+            min_length: None,
+            max_items: None,
+            min_items: None,
+            unique_items: false,
+            max_properties: None,
+            min_properties: None,
+            multiple_of: None,
+            maximum: None,
+            exclusive_maximum: None,
+            minimum: None,
+            exclusive_minimum: None,
+            r#enum: None,
+            r#const: None,
         };
         let run_cmd_tool = rmcp::model::Tool {
-            name: "run_command".to_string(),
-            description: Some("Runs a raw Luau command string in Roblox Studio.".to_string()),
-            inputs: Some(rmcp::model::Schema::Object(run_cmd_params)),
-            outputs: None,
+            name: "run_command".to_string().into(),
+            description: Some("Runs a raw Luau command string in Roblox Studio.".to_string().into()),
+            input_schema: Some(Schema::Object(run_cmd_schema_object_data)),
+            annotations: None,
         };
         tools_list.push(run_cmd_tool);
 
@@ -399,22 +454,49 @@ impl ServerHandler for RBXStudioServer {
             props.insert("query".to_string(), rmcp::serde_json::json!({"type": "string", "description": "Query to search for the model."}));
             props
         };
-        let insert_model_params = rmcp::model::Parameters {
-            r#type: "object".to_string(),
-            properties: insert_model_params_props,
-            required: vec!["query".to_string()],
+        let insert_model_schema_object_data = rmcp::model::SchemaObject {
+            properties: insert_model_params_props.into_iter().map(|(k, v)| (k.into(), Schema::from_json_value(v).unwrap_or_else(|e| panic!("Failed to convert Value to Schema for insert_model_params_props property {}: {}", k, e)) )).collect(),
+            required: vec!["query".to_string()].into_iter().map(|s| s.into()).collect(),
+            description: None,
+            default_value: None,
+            read_only: false,
+            write_only: false,
+            examples: None,
+            all_of: None,
+            any_of: None,
+            one_of: None,
+            not: None,
+            r#if: None,
+            then: None,
+            r#else: None,
+            format: None,
+            pattern: None,
+            max_length: None,
+            min_length: None,
+            max_items: None,
+            min_items: None,
+            unique_items: false,
+            max_properties: None,
+            min_properties: None,
+            multiple_of: None,
+            maximum: None,
+            exclusive_maximum: None,
+            minimum: None,
+            exclusive_minimum: None,
+            r#enum: None,
+            r#const: None,
         };
         let insert_model_tool = rmcp::model::Tool {
-            name: "insert_model".to_string(),
-            description: Some("Inserts a model from the Roblox marketplace into the workspace.".to_string()),
-            inputs: Some(rmcp::model::Schema::Object(insert_model_params)),
-            outputs: None,
+            name: "insert_model".to_string().into(),
+            description: Some("Inserts a model from the Roblox marketplace into the workspace.".to_string().into()),
+            input_schema: Some(Schema::Object(insert_model_schema_object_data)),
+            annotations: None,
         };
         tools_list.push(insert_model_tool);
 
         let mut capabilities = ServerCapabilities::default();
         capabilities.tools = Some(ToolsCapability {
-            tools: tools_list,
+            available_tools: tools_list,
             list_changed: Some(true),
             // No other tool capabilities like 'definition_provider' are being set here.
         });
@@ -429,7 +511,7 @@ impl ServerHandler for RBXStudioServer {
             instructions: Some(
                 format!("Use 'execute_discovered_luau_tool' to run discovered Luau scripts by name. Discovered Luau tools: [{}]. Also available: run_command (direct Luau string), insert_model.",
                     self.discovered_luau_tools.keys().cloned().collect::<Vec<String>>().join(", ")
-                )
+                ).into()
             ),
             capabilities,
         }


### PR DESCRIPTION
This attempt addresses errors from the previous build:

- I corrected the Schema import to use `rmcp::model::Schema`.
- I refactored tool parameter definitions (`exec_tool_params`, etc.) to be instances of `rmcp::model::SchemaObject`. This involves:
    - Removing the `r#type` field (implicit in `Schema::Object`).
    - Converting `properties` from `serde_json::Map<String, Value>` to `BTreeMap<Cow<str>, Schema>` (assuming `Schema::from_json_value()` for conversion).
    - Converting `required` from `Vec<String>` to `Vec<Cow<str>>`.
    - Initializing other `SchemaObject` fields to default/None.
- I added the missing `annotations: None,` field to `rmcp::model::Tool` initializers.
- I changed the field in `ToolsCapability` for holding the tool list to `available_tools`.