### PR TITLE
Fix compilation errors in rbx_studio_server.rs (Attempt 3)

### DIFF
--- a/src/rbx_studio_server.rs
+++ b/src/rbx_studio_server.rs
@@ -12,6 +12,10 @@ use rmcp::schemars;
 use rmcp::tool;
 use rmcp::{Error as McpError, ServerHandler};
 
+// Corrected Schema imports
+use crate::rbx_studio_server::schemars::schema::Schema;
+use crate::rbx_studio_server::schemars::schema::SchemaObject;
+
 use std::collections::{HashMap, VecDeque};
 // use serde_json::Value; // Likely not needed if serde_json::Map and json! macro are used
 use std::path::{Path, PathBuf};
@@ -358,19 +362,49 @@ impl ServerHandler for RBXStudioServer {
             props.insert("tool_arguments_str".to_string(), rmcp::serde_json::json!({"type": "string", "description": "A JSON string representing arguments for the Luau tool."}));
             props
         };
-        let exec_tool_params = rmcp::model::Parameters {
-            r#type: "object".to_string(),
-            properties: exec_tool_params_props,
+        let exec_tool_schema_object_data = SchemaObject {
+            properties: exec_tool_params_props.into_iter().map(|(k, v)| {
+                let schema_val: Schema = rmcp::serde_json::from_value(v).expect("Failed to deserialize property JSON into Schema");
+                (k, schema_val)
+            }).collect(),
             required: vec!["tool_name".to_string(), "tool_arguments_str".to_string()],
+            description: None,
+            default_value: None,
+            read_only: false,
+            write_only: false,
+            examples: None,
+            all_of: None,
+            any_of: None,
+            one_of: None,
+            not: None,
+            r#if: None,
+            then: None,
+            r#else: None,
+            format: None,
+            pattern: None,
+            max_length: None,
+            min_length: None,
+            max_items: None,
+            min_items: None,
+            unique_items: false,
+            max_properties: None,
+            min_properties: None,
+            multiple_of: None,
+            maximum: None,
+            exclusive_maximum: None,
+            minimum: None,
+            exclusive_minimum: None,
+            r#enum: None,
+            r#const: None,
         };
         let exec_tool = rmcp::model::Tool {
-            name: "execute_discovered_luau_tool".to_string(),
+            name: "execute_discovered_luau_tool".to_string().into(),
             description: Some(format!(
                 "Executes a specific Luau tool script by its name. Available Luau tools: [{}]",
                 self.discovered_luau_tools.keys().cloned().collect::<Vec<String>>().join(", ")
-            )),
-            inputs: Some(rmcp::model::Schema::Object(exec_tool_params)),
-            outputs: None,
+            ).into()),
+            input_schema: Some(Schema::Object(exec_tool_schema_object_data)),
+            annotations: None,
         };
         tools_list.push(exec_tool);
 
@@ -380,16 +414,46 @@ impl ServerHandler for RBXStudioServer {
             props.insert("command".to_string(), rmcp::serde_json::json!({"type": "string", "description": "The Luau code to execute."}));
             props
         };
-        let run_cmd_params = rmcp::model::Parameters {
-            r#type: "object".to_string(),
-            properties: run_cmd_params_props,
+        let run_cmd_schema_object_data = SchemaObject {
+            properties: run_cmd_params_props.into_iter().map(|(k, v)| {
+                let schema_val: Schema = rmcp::serde_json::from_value(v).expect("Failed to deserialize property JSON into Schema");
+                (k, schema_val)
+            }).collect(),
             required: vec!["command".to_string()],
+            description: None,
+            default_value: None,
+            read_only: false,
+            write_only: false,
+            examples: None,
+            all_of: None,
+            any_of: None,
+            one_of: None,
+            not: None,
+            r#if: None,
+            then: None,
+            r#else: None,
+            format: None,
+            pattern: None,
+            max_length: None,
+            min_length: None,
+            max_items: None,
+            min_items: None,
+            unique_items: false,
+            max_properties: None,
+            min_properties: None,
+            multiple_of: None,
+            maximum: None,
+            exclusive_maximum: None,
+            minimum: None,
+            exclusive_minimum: None,
+            r#enum: None,
+            r#const: None,
         };
         let run_cmd_tool = rmcp::model::Tool {
-            name: "run_command".to_string(),
-            description: Some("Runs a raw Luau command string in Roblox Studio.".to_string()),
-            inputs: Some(rmcp::model::Schema::Object(run_cmd_params)),
-            outputs: None,
+            name: "run_command".to_string().into(),
+            description: Some("Runs a raw Luau command string in Roblox Studio.".to_string().into()),
+            input_schema: Some(Schema::Object(run_cmd_schema_object_data)),
+            annotations: None,
         };
         tools_list.push(run_cmd_tool);
 
@@ -399,25 +463,51 @@ impl ServerHandler for RBXStudioServer {
             props.insert("query".to_string(), rmcp::serde_json::json!({"type": "string", "description": "Query to search for the model."}));
             props
         };
-        let insert_model_params = rmcp::model::Parameters {
-            r#type: "object".to_string(),
-            properties: insert_model_params_props,
+        let insert_model_schema_object_data = SchemaObject {
+            properties: insert_model_params_props.into_iter().map(|(k, v)| {
+                let schema_val: Schema = rmcp::serde_json::from_value(v).expect("Failed to deserialize property JSON into Schema");
+                (k, schema_val)
+            }).collect(),
             required: vec!["query".to_string()],
+            description: None,
+            default_value: None,
+            read_only: false,
+            write_only: false,
+            examples: None,
+            all_of: None,
+            any_of: None,
+            one_of: None,
+            not: None,
+            r#if: None,
+            then: None,
+            r#else: None,
+            format: None,
+            pattern: None,
+            max_length: None,
+            min_length: None,
+            max_items: None,
+            min_items: None,
+            unique_items: false,
+            max_properties: None,
+            min_properties: None,
+            multiple_of: None,
+            maximum: None,
+            exclusive_maximum: None,
+            minimum: None,
+            exclusive_minimum: None,
+            r#enum: None,
+            r#const: None,
         };
         let insert_model_tool = rmcp::model::Tool {
-            name: "insert_model".to_string(),
-            description: Some("Inserts a model from the Roblox marketplace into the workspace.".to_string()),
-            inputs: Some(rmcp::model::Schema::Object(insert_model_params)),
-            outputs: None,
+            name: "insert_model".to_string().into(),
+            description: Some("Inserts a model from the Roblox marketplace into the workspace.".to_string().into()),
+            input_schema: Some(Schema::Object(insert_model_schema_object_data)),
+            annotations: None,
         };
         tools_list.push(insert_model_tool);
 
         let mut capabilities = ServerCapabilities::default();
-        capabilities.tools = Some(ToolsCapability {
-            tools: tools_list,
-            list_changed: Some(true),
-            // No other tool capabilities like 'definition_provider' are being set here.
-        });
+        capabilities.tools = Some(rmcp::model::ToolsCapability(tools_list, Some(true)));
 
         if self.discovered_luau_tools.is_empty() {
             tracing::warn!("No Luau tools found in RBXStudioServer state during get_info. 'execute_discovered_luau_tool' might not list any specific scripts.");
@@ -429,7 +519,7 @@ impl ServerHandler for RBXStudioServer {
             instructions: Some(
                 format!("Use 'execute_discovered_luau_tool' to run discovered Luau scripts by name. Discovered Luau tools: [{}]. Also available: run_command (direct Luau string), insert_model.",
                     self.discovered_luau_tools.keys().cloned().collect::<Vec<String>>().join(", ")
-                )
+                ).into()
             ),
             capabilities,
         }


### PR DESCRIPTION
This attempt addresses errors from the previous build, with a focus on using `schemars` for schema definitions:

- Updated imports for `Schema` and `SchemaObject` to use types from `crate::rbx_studio_server::schemars::schema`.
- Refactored `SchemaObject` initializations:
    - `properties` are now `BTreeMap<String, schemars::schema::Schema>`, with `Schema` values created by deserializing `serde_json::Value` (e.g., `json!({"type": "string"})`) from the original props map.
    - `required` field is now `Vec<String>`.
    - Other `SchemaObject` fields kept with default/None values.
- Modified `rmcp::model::ToolsCapability` initialization to use a tuple struct format: `ToolsCapability(tools_list, Some(true))`.
- Removed unused import `rmcp::handler::server::tool::Parameters`.