### PR TITLE
Fix Luau plugin encoding, error handling, and add diagnostics

### DIFF
--- a/plugin/src/Main.server.luau
+++ b/plugin/src/Main.server.luau
@@ -34,32 +34,62 @@ end
 
 -- New: Load tools into a dictionary for named dispatch
 local function loadToolFunctions()
+    print("[MCP Diagnostics] Attempting to load tool functions...")
     local toolModules = {}
-    local toolsFolder = Main.Tools or script.Tools -- Prefer Main.Tools if defined, else script.Tools
+
+    print("[MCP Diagnostics] Main (script:FindFirstAncestor(\"MCPStudioPlugin\")) is: " .. tostring(Main))
+    if Main then
+        print("[MCP Diagnostics] Main.Tools is: " .. tostring(Main.Tools))
+    else
+        print("[MCP Diagnostics] Main is nil, cannot access Main.Tools.")
+    end
+    print("[MCP Diagnostics] script.Tools is: " .. tostring(script.Tools))
+
+    local toolsFolder = Main and Main.Tools or script.Tools -- Check Main before Main.Tools
+    print("[MCP Diagnostics] Determined toolsFolder: " .. tostring(toolsFolder) .. (toolsFolder and (" (" .. toolsFolder:GetFullName() .. ")") or ""))
 
     if toolsFolder then
-        for _, toolModuleScript in ipairs(toolsFolder:GetChildren()) do
+        print("[MCP Diagnostics] Tools folder found. Iterating children...")
+        local children = toolsFolder:GetChildren()
+        print("[MCP Diagnostics] Number of children in toolsFolder: " .. tostring(#children))
+        for i, toolModuleScript in ipairs(children) do
+            print("[MCP Diagnostics] Processing child #" .. i .. ": " .. toolModuleScript.Name .. ", ClassName: " .. toolModuleScript.ClassName)
             if toolModuleScript:IsA("ModuleScript") then
-                local success, toolFunction = pcall(require, toolModuleScript)
-                if success and type(toolFunction) == "function" then
-                    log("[MCP] Loaded tool: " .. toolModuleScript.Name)
-                    toolModules[toolModuleScript.Name] = toolFunction
+                print("[MCP Diagnostics] Attempting to require ModuleScript: " .. toolModuleScript.Name)
+                local success, toolFunctionOrError = pcall(require, toolModuleScript)
+                if success and type(toolFunctionOrError) == "function" then
+                    print("[MCP Diagnostics] Successfully loaded tool: " .. toolModuleScript.Name)
+                    toolModules[toolModuleScript.Name] = toolFunctionOrError
+                elseif success then
+                    print("[MCP Diagnostics] Error loading tool " .. toolModuleScript.Name .. ": require succeeded but returned type " .. type(toolFunctionOrError) .. " instead of function.")
                 else
-                    log("[MCP] Error loading tool " .. toolModuleScript.Name .. ": " .. tostring(toolFunction))
+                    print("[MCP Diagnostics] Error loading tool " .. toolModuleScript.Name .. " (pcall failed): " .. tostring(toolFunctionOrError))
                 end
+            else
+                print("[MCP Diagnostics] Child " .. toolModuleScript.Name .. " is not a ModuleScript. Skipping.")
             end
         end
     else
-        log("[MCP] Error: Tools folder not found.")
+        print("[MCP Diagnostics] Error: Tools folder not found or resolved to nil.")
     end
+
+    local loadedToolNames = {}
+    for name, _ in pairs(toolModules) do
+        table.insert(loadedToolNames, name)
+    end
+    print("[MCP Diagnostics] Finished loading tools. Loaded tool names: {" .. table.concat(loadedToolNames, ", ") .. "}")
+
     return toolModules
 end
 
 local toolFunctions = loadToolFunctions()
 -- For debugging, print loaded tools
-for name, _ in pairs(toolFunctions) do
-    log("[MCP] Registered tool function: " .. name)
-end
+-- for name, _ in pairs(toolFunctions) do
+-- log("[MCP] Registered tool function: " .. name) -- Keep this commented or use print for consistency
+-- end
+-- for name, _ in pairs(toolFunctions) do
+-- log("[MCP] Registered tool function: " .. name) -- Keep this commented or use print for consistency
+-- end
 
 local function connectWebSocket()
 	local client = MockWebSocketService:CreateClient(URI)
@@ -97,13 +127,26 @@ local function connectWebSocket()
 				-- responseCallToolResultTable is the Lua table like {content={{type="text",...}}, isError=...}
 				-- This is what needs to be JSON encoded and sent as the 'response' field of the body to /response
 
-				local jsonEncodedCallToolResultStr, encodeErr = pcall(HttpService.JSONEncode, HttpService, responseCallToolResultTable)
-				if encodeErr then -- If encoding the CallToolResult-like table itself fails
-					local errorDetail = "Plugin internal error: Failed to JSON encode the tool's result structure: " .. tostring(jsonEncodedCallToolResultStr) -- jsonEncodedCallToolResultStr is error here
+				local successEncode, resultOrError = pcall(HttpService.JSONEncode, HttpService, responseCallToolResultTable)
+				local jsonEncodedCallToolResultStr
+
+				if not successEncode then
+					-- resultOrError is the error message from the failed JSONEncode
+					local errorDetail = "Plugin internal error: Failed to JSON encode the tool's result structure: " .. tostring(resultOrError)
 					log("[MCP] CRITICAL: " .. errorDetail)
-					-- Create a valid CallToolResult structure representing this encoding error
 					local errorCtResultTable = ToolHelpers.FormatErrorResult(errorDetail)
-					jsonEncodedCallToolResultStr = HttpService:JSONEncode(errorCtResultTable) -- Re-encode the error CallToolResult
+					-- Safely encode the new error table (this should ideally not fail if FormatErrorResult is simple)
+					local finalErrorJsonSuccess, finalErrorJson = pcall(HttpService.JSONEncode, HttpService, errorCtResultTable)
+					if finalErrorJsonSuccess then
+						jsonEncodedCallToolResultStr = finalErrorJson
+					else
+						-- If even encoding the fallback error fails, create a very basic JSON string manually
+						log("[MCP] CRITICAL: Failed to encode even the fallback error message! " .. tostring(finalErrorJson))
+						jsonEncodedCallToolResultStr = "{\"content\":[{\"type\":\"text\",\"text\":\"Plugin critical error: Failed to construct JSON response.\"}],\"isError\":true}"
+					end
+				else
+					-- resultOrError is the successfully encoded JSON string
+					jsonEncodedCallToolResultStr = resultOrError
 				end
 
 				local payloadForRust = { -- This is the body for the POST to the /response endpoint

--- a/plugin/src/MockWebSocketService.luau
+++ b/plugin/src/MockWebSocketService.luau
@@ -65,6 +65,15 @@ function MockWebSocketClient.new(uri: string): MockWebSocketClient
 end
 
 local function doRequest(url: string, method: "GET" | "POST", body: any)
+	local requestBody
+	if type(body) == "string" then
+		requestBody = body -- Use string body directly
+	elseif body then
+		requestBody = HttpService:JSONEncode(body) -- Encode if not already a string (and not nil)
+	else
+		requestBody = nil
+	end
+
 	local ok, response = pcall(function()
 		return HttpService:RequestAsync({
 			Url = url,
@@ -72,7 +81,7 @@ local function doRequest(url: string, method: "GET" | "POST", body: any)
 			Headers = {
 				["Content-Type"] = "application/json",
 			},
-			Body = if body then HttpService:JSONEncode(body) else nil,
+			Body = requestBody, -- Use the processed requestBody
 			Compress = Enum.HttpCompression.None,
 		})
 	end)


### PR DESCRIPTION
This commit addresses several issues in the Luau plugin:

1.  **Fix Double Encoding:** Modified `MockWebSocketService.luau` to prevent double JSON encoding of responses sent to the MCP server. The `doRequest` function now checks if the body is already a string and uses it directly, otherwise it encodes.
2.  **Improve pcall Logic:** Corrected the `pcall` handling for `HttpService.JSONEncode` in `Main.server.luau`'s `sendResponseOnce` function. This ensures that encoding errors are properly caught and reported.
3.  **Add Diagnostic Logging:** Added extensive `print()` statements to the `loadToolFunctions` in `Main.server.luau` to provide detailed insight into the function discovery and loading process within the Roblox Studio environment.

These changes aim to resolve errors related to execution failures and improve the debuggability of the Luau plugin.