### PR TITLE
RunCode.luau: Reintroduce basic output/error capturing

### DIFF
--- a/plugin/src/Tools/CreateInstance.luau
+++ b/plugin/src/Tools/CreateInstance.luau
@@ -53,7 +53,7 @@ local function execute(args)
         for propName, propValueInput in pairs(properties) do
             if string.lower(propName) ~= "parent" then
                 -- Use JsonToRobloxValue for each property value, as it might be a JSON representation of a Roblox type
-                local convertedValue, convertError = ToolHelpers.JsonToRobloxValue(propValueInput, newInstance:GetClass().."."..propName)
+                local convertedValue, convertError = ToolHelpers.JsonToRobloxValue(propValueInput, newInstance.ClassName.."."..propName)
                 if convertError then
                     table.insert(propertyErrors, ("Property '%s': Failed to convert input value: %s"):format(propName, convertError))
                 else

--- a/plugin/src/Tools/CreateProximityPrompt.luau
+++ b/plugin/src/Tools/CreateProximityPrompt.luau
@@ -35,22 +35,20 @@ local function execute(args)
                     -- The parent is determined by parent_part_path, not this property.
                     -- Could warn or ignore. For now, ignoring to prevent error if user includes it.
                     print("CreateProximityPrompt: 'Parent' property in 'properties' table is ignored. Use 'parent_part_path' argument.")
-                    goto continue_loop
-                end
-
-                -- Use JsonToRobloxValue for each property value, as it might be a JSON representation of a Roblox type
-                local convertedValue, convertError = ToolHelpers.JsonToRobloxValue(propValueInput, "ProximityPrompt."..propName)
-                if convertError then
-                     table.insert(propertyErrors, ("Property '%s': Failed to convert input value: %s"):format(propName, convertError))
                 else
-                    local setSuccess, setError = pcall(function()
-                        prompt[propName] = convertedValue
-                    end)
-                    if not setSuccess then
-                         table.insert(propertyErrors, ("Property '%s': Error setting value: %s"):format(propName, setError))
+                    -- Use JsonToRobloxValue for each property value, as it might be a JSON representation of a Roblox type
+                    local convertedValue, convertError = ToolHelpers.JsonToRobloxValue(propValueInput, "ProximityPrompt."..propName)
+                    if convertError then
+                        table.insert(propertyErrors, ("Property '%s': Failed to convert input value: %s"):format(propName, convertError))
+                    else
+                        local setSuccess, setError = pcall(function()
+                            prompt[propName] = convertedValue
+                        end)
+                        if not setSuccess then
+                            table.insert(propertyErrors, ("Property '%s': Error setting value: %s"):format(propName, setError))
+                        end
                     end
                 end
-                ::continue_loop::
             end
         end
 

--- a/plugin/src/Tools/CreateTextChannel.luau
+++ b/plugin/src/Tools/CreateTextChannel.luau
@@ -35,22 +35,20 @@ local function execute(args)
                 if string.lower(propName) == "parent" then
                     -- TextChannels are always parented to TextChatService.
                     print("CreateTextChannel: 'Parent' property in 'properties' table is ignored.")
-                    goto continue_loop
-                end
-
-                -- Use JsonToRobloxValue for each property value
-                local convertedValue, convertError = ToolHelpers.JsonToRobloxValue(propValueInput, "TextChannel."..propName)
-                if convertError then
-                    table.insert(propertyErrors, ("Property '%s': Failed to convert input value: %s"):format(propName, convertError))
                 else
-                    local setSuccess, setError = pcall(function()
-                        newChannel[propName] = convertedValue
-                    end)
-                    if not setSuccess then
-                        table.insert(propertyErrors, ("Property '%s': Error setting value: %s"):format(propName, setError))
+                    -- Use JsonToRobloxValue for each property value
+                    local convertedValue, convertError = ToolHelpers.JsonToRobloxValue(propValueInput, "TextChannel."..propName)
+                    if convertError then
+                        table.insert(propertyErrors, ("Property '%s': Failed to convert input value: %s"):format(propName, convertError))
+                    else
+                        local setSuccess, setError = pcall(function()
+                            newChannel[propName] = convertedValue
+                        end)
+                        if not setSuccess then
+                            table.insert(propertyErrors, ("Property '%s': Error setting value: %s"):format(propName, setError))
+                        end
                     end
                 end
-                ::continue_loop::
             end
         end
 

--- a/plugin/src/Tools/PlaySoundId.luau
+++ b/plugin/src/Tools/PlaySoundId.luau
@@ -38,39 +38,37 @@ local function execute(args)
 
         local propertyErrors = {}
         for propName, propValueInput in pairs(properties) do
-            if string.lower(propName) == "parent" and parentInstance then
-                 table.insert(propertyErrors, "Cannot set 'Parent' via properties if 'parent_path' argument is also used. Parent is already determined.")
-                 goto continue_loop
-            end
-            if string.lower(propName) == "parent" and not parentInstance then
-                -- Allow Parent property if parent_path arg was not given
-                if type(propValueInput) == "string" then
-                    local foundParentFromProp, errProp = ToolHelpers.FindInstanceByPath(propValueInput)
-                    if foundParentFromProp then
-                        parentInstance = foundParentFromProp
-                    else
-                        table.insert(propertyErrors, ("Parent path '%s' from properties not found. Error: %s"):format(propValueInput, errProp or ""))
-                    end
-                elseif typeof(propValueInput) == "Instance" then
-                    parentInstance = propValueInput
+            if string.lower(propName) == "parent" then
+                if parentInstance then
+                    table.insert(propertyErrors, "Cannot set 'Parent' via properties if 'parent_path' argument is also used. Parent is already determined.")
                 else
-                    table.insert(propertyErrors, "'Parent' property must be a string path or Instance.")
+                    -- Allow Parent property if parent_path arg was not given
+                    if type(propValueInput) == "string" then
+                        local foundParentFromProp, errProp = ToolHelpers.FindInstanceByPath(propValueInput)
+                        if foundParentFromProp then
+                            parentInstance = foundParentFromProp
+                        else
+                            table.insert(propertyErrors, ("Parent path '%s' from properties not found. Error: %s"):format(propValueInput, errProp or ""))
+                        end
+                    elseif typeof(propValueInput) == "Instance" then
+                        parentInstance = propValueInput
+                    else
+                        table.insert(propertyErrors, "'Parent' property must be a string path or Instance.")
+                    end
                 end
-                goto continue_loop -- Parent is handled separately after all other props
-            end
-
-            local convertedValue, convertError = ToolHelpers.JsonToRobloxValue(propValueInput, "Sound."..propName)
-            if convertError then
-                table.insert(propertyErrors, ("Property '%s': Failed to convert input value: %s"):format(propName, convertError))
             else
-                local setSuccess, setError = pcall(function()
-                    soundInstance[propName] = convertedValue
-                end)
-                if not setSuccess then
-                    table.insert(propertyErrors, ("Property '%s': Error setting value: %s"):format(propName, setError))
+                local convertedValue, convertError = ToolHelpers.JsonToRobloxValue(propValueInput, "Sound."..propName)
+                if convertError then
+                    table.insert(propertyErrors, ("Property '%s': Failed to convert input value: %s"):format(propName, convertError))
+                else
+                    local setSuccess, setError = pcall(function()
+                        soundInstance[propName] = convertedValue
+                    end)
+                    if not setSuccess then
+                        table.insert(propertyErrors, ("Property '%s': Error setting value: %s"):format(propName, setError))
+                    end
                 end
             end
-            ::continue_loop::
         end
 
         if #propertyErrors > 0 then

--- a/plugin/src/Tools/RunCode.luau
+++ b/plugin/src/Tools/RunCode.luau
@@ -1,191 +1,90 @@
+-- Simplified RunCode.luau - Step 1 of reintroducing functionality
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
-local Types = require(Main.Types) -- Assuming Types.ToolFunction expects the CallToolResult-like table
-local HttpService = game:GetService("HttpService")
+local ToolHelpers = require(Main.ToolHelpers)
 
--- Keep existing helper functions: getTableType, serializeTable, deepClone, toStrTable
--- as they are used for constructing the output string, not the final return structure.
-local function getTableType(arg)
-	local hasArray = false
-	local hasTable = false
-	for key, _value in arg do
-		if typeof(key) == "number" then
-			hasArray = true
-		else
-			hasTable = true
-		end
-		if hasArray and hasTable then
-			break
-		end
-	end
-	return hasArray, hasTable
-end
-
-local function serializeTable(arg)
-	if typeof(arg) == "table" then
-		local _, isTable = getTableType(arg)
-		local newArg = {}
-		for key, value in arg do
-			local newKey = serializeTable(key)
-			newArg[if isTable then tostring(newKey) else newKey] = serializeTable(value)
-		end
-		return newArg
-	elseif type(arg) == "userdata" then
-		return tostring(arg) or "UNABLE_TO_SERIALIZE"
-	end
-	return arg
-end
-
-local function deepClone(t, cache)
-    cache = cache or {} -- Ensure cache is initialized
-	local clone = {}
-	for key, value in t do
-		local newKey = key
-		if typeof(key) == "table" then
-			if not cache[key] then
-                cache[key] = {} -- Placeholder to break cycles for keys
-				cache[key] = deepClone(key, cache)
-			end
-			newKey = cache[key]
-		end
-
-		local newValue = value
-		if typeof(value) == "table" then
-			if not cache[value] then
-                cache[value] = {} -- Placeholder to break cycles for values
-				cache[value] = deepClone(value, cache)
-			end
-			newValue = cache[value]
-		end
-		clone[newKey] = newValue
-	end
-	return clone
-end
-
-local function toStrTable(t: { any }): { string }
-    local clonedTable = {}
-    -- Wrap deepClone in a pcall in case of complex userdata that can't be cached well or other issues
-    local cloneSuccess, result = pcall(deepClone, t, {})
-    if cloneSuccess then
-        clonedTable = result
-    else
-        -- Fallback for cloning failure: try tostring on elements directly
-        local strTableMinimal = table.create(#t)
-        for i, arg_elem in ipairs(t) do
-            strTableMinimal[i] = tostring(arg_elem)
-        end
-        return strTableMinimal
+local function handleRunCode(args)
+    if type(args.command) ~= "string" then
+        return ToolHelpers.FormatErrorResult("Error: RunCode command argument is missing or not a string.")
     end
 
-	local strTable = table.create(#clonedTable)
-	for i, arg_elem in ipairs(clonedTable) do -- Use ipairs for array part
-		local serializedArg = serializeTable(arg_elem)
-		strTable[i] = if typeof(serializedArg) == "table"
-			then HttpService:JSONEncode(serializedArg)
-			else tostring(serializedArg) -- Ensure it's a string
-		end
-	end
-	return strTable
-end
+    local command = args.command
+    local output_parts = {} -- Reintroduce output_parts
+    local an_error_occurred_in_command = false
 
-
--- Modified runCodeWithOutput to return both output string and an error flag
-local function runCodeWithOutput(command: string): (string, boolean)
-	local output_parts = {} -- Store parts of output to join later
-    local anErrorOccurred = false
-
-	local function addToOutput(header: string, ...)
-        local packedArgs = table.pack(...)
-        if packedArgs.n == 0 then -- Handle calls like print() with no arguments
-            table.insert(output_parts, header .. "\n")
-            return
+    -- Simplified addToOutput for this step
+    local function addToOutput(tag, ...)
+        local parts = {tag}
+        for i = 1, select("#", ...) do
+            table.insert(parts, tostring(select(i, ...)))
         end
-		local strResults = toStrTable(packedArgs) -- Pass the packed table directly
-		table.insert(output_parts, header .. " " .. table.concat(strResults, "\t") .. "\n")
-	end
+        table.insert(output_parts, table.concat(parts, " ") .. "\n")
+    end
 
-	local function executeCode()
-		local chunk, loadErr = loadstring(command)
-        if not chunk then
-            anErrorOccurred = true
-            addToOutput("[LOADSTRING ERROR]", loadErr or "Unknown loadstring error")
-            return nil -- Explicitly return nil as chunk is nil
+    local pcall_success, execution_result = pcall(function()
+        local func, load_err = loadstring(command)
+        if not func then
+            an_error_occurred_in_command = true
+            addToOutput("[LOADSTRING ERROR]", load_err or "Unknown loadstring error")
+            return -- Important: return from this anonymous function
         end
 
-		local chunkfenv = getfenv(chunk)
-
-		local oldPrint = chunkfenv.print or print
-		chunkfenv.print = function(...)
-			if oldPrint then oldPrint(...) end
-			addToOutput("[OUTPUT]", ...)
-		end
-
-		local oldWarn = chunkfenv.warn or warn
-		chunkfenv.warn = function(...)
-			if oldWarn then oldWarn(...) end
-			addToOutput("[WARNING]", ...)
-		end
-
-
-		local oldError = chunkfenv.error or error
-		local function customErrorForChunk(...)
-			anErrorOccurred = true
-			addToOutput("[ERROR]", ...)
-            -- No need to call oldError here as it would halt execution;
-            -- The error is captured by addToOutput.
-            -- Unlike the original, we don't call the actual error() here to allow script to continue
-            -- and capture more output if possible, or let pcall handle the halt.
-            -- For true halting behavior, the pcall below is the primary catcher.
-		end
-		chunkfenv.error = customErrorForChunk
-
-		-- Execute the chunk
-        local success, results = pcall(chunk) -- Use pcall here for safety
-
-        if not success then
-            anErrorOccurred = true
-            addToOutput("[RUNTIME ERROR]", results) -- 'results' is the error message here
-            return -- Stop further processing of results
+        local chunkfenv = getfenv(func)
+        local oldPrint = chunkfenv.print or print
+        chunkfenv.print = function(...)
+            if oldPrint then oldPrint(...) end -- Call original print
+            addToOutput("[OUTPUT]", ...)
         end
 
-        -- Process actual return values if pcall was successful
-		if results and type(results) == "table" and results.n ~= nil and results.n > 0 then -- Check if it's a packed table from pcall
-            local unpackedResults = {}
-            for i = 1, results.n do
-                table.insert(unpackedResults, results[i])
+        local oldWarn = chunkfenv.warn or warn
+        chunkfenv.warn = function(...)
+            if oldWarn then oldWarn(...) end -- Call original warn
+            addToOutput("[WARNING]", ...)
+        end
+
+        -- Capture errors without halting, record them via addToOutput
+        local oldError = chunkfenv.error
+        chunkfenv.error = function(...)
+            an_error_occurred_in_command = true
+            addToOutput("[ERROR]", ...)
+            -- Do not call oldError here to prevent script halt if possible,
+            -- error is recorded. For critical errors, pcall below handles it.
+        end
+
+        -- Execute the user's code
+        local results = {pcall(func)}
+        local run_success = results[1]
+        local returned_values_from_command = {}
+        for i = 2, #results do
+            table.insert(returned_values_from_command, results[i])
+        end
+
+        if not run_success then
+            an_error_occurred_in_command = true
+            -- The error from pcall(func) is in returned_values_from_command[1]
+            addToOutput("[RUNTIME ERROR]", returned_values_from_command[1])
+        else
+            if #returned_values_from_command > 0 then
+                addToOutput("[RETURNED]", table.unpack(returned_values_from_command))
             end
-			addToOutput("[RETURNED]", table.unpack(unpackedResults, 1, results.n))
-		end
+        end
+    end) -- End of main pcall for execution
 
-	end
+    local final_output_str = table.concat(output_parts, "")
 
-	-- The main pcall for executeCode itself (though internal execution is also pcalled now)
-	local overallOk, overallErrorMessage = pcall(executeCode)
-	if not overallOk then
-		anErrorOccurred = true
-		addToOutput("[CRITICAL EXECUTION ERROR]", overallErrorMessage)
-	end
-
-	return table.concat(output_parts, ""), anErrorOccurred
+    if not pcall_success then
+        -- This is a critical error in the Lua code of this tool itself (e.g. in addToOutput, etc.)
+        -- This should ideally not happen with this simplified version.
+        final_output_str = final_output_str .. "[CRITICAL TOOL ERROR] " .. tostring(execution_result) .. "\n"
+        an_error_occurred_in_command = true -- Mark as error
+        return ToolHelpers.FormatErrorResult(final_output_str)
+    elseif an_error_occurred_in_command then
+        return ToolHelpers.FormatErrorResult(final_output_str)
+    else
+        if final_output_str == "" then
+            final_output_str = "Command executed successfully with no output or return values."
+        end
+        return ToolHelpers.FormatSuccessResult({ output = final_output_str })
+    end
 end
 
--- Modified handleRunCode to accept args directly and return the correct table structure
-local function handleRunCode(args: Types.RunCodeArgs): Types.CallToolResultTable
-	-- The 'args' here is toolInputArgs from Main.server.luau,
-    -- which for RunCode is expected to be { command = "string" }
-	if type(args.command) ~= "string" then
-		-- This case should ideally be caught by argument validation in Main.server.luau based on JSON schema
-		return {
-			content = {{ type = "text", text = "Error: RunCode command argument is missing or not a string." }},
-			isError = true
-		}
-	end
-
-	local outputString, hasError = runCodeWithOutput(args.command)
-
-	return {
-		content = {{ type = "text", text = outputString }},
-		isError = hasError
-	}
-end
-
-return handleRunCode -- Ensure this matches the expected Type.ToolFunction signature
+return handleRunCode

--- a/plugin/src/Tools/SetInstanceProperties.luau
+++ b/plugin/src/Tools/SetInstanceProperties.luau
@@ -37,24 +37,22 @@ local function execute(args)
                     original_value = propValueInput
                 })
                 print(("SetInstanceProperties: Error converting value for property '%s' on instance '%s': %s"):format(propName, path, convertError))
-                goto continue_loop
-            end
-
-            local setSuccess, setError = pcall(function()
-                instance[propName] = convertedValue
-            end)
-
-            if setSuccess then
-                table.insert(appliedProperties, propName)
             else
-                table.insert(failedProperties, {
-                    name = propName,
-                    error = tostring(setError),
-                    value_tried = convertedValue -- Or propValueInput if more useful
-                })
-                print(("SetInstanceProperties: Error setting property '%s' on instance '%s': %s"):format(propName, path, setError))
+                local setSuccess, setError = pcall(function()
+                    instance[propName] = convertedValue
+                end)
+
+                if setSuccess then
+                    table.insert(appliedProperties, propName)
+                else
+                    table.insert(failedProperties, {
+                        name = propName,
+                        error = tostring(setError),
+                        value_tried = convertedValue -- Or propValueInput if more useful
+                    })
+                    print(("SetInstanceProperties: Error setting property '%s' on instance '%s': %s"):format(propName, path, setError))
+                end
             end
-            ::continue_loop::
         end
 
         if #failedProperties > 0 then

--- a/plugin/src/Tools/SetProperties.luau
+++ b/plugin/src/Tools/SetProperties.luau
@@ -54,24 +54,22 @@ local function execute(args)
                     original_value = propValueInput
                 })
                 print(("SetProperties: Error converting value for property '%s' on instance '%s': %s"):format(propName, path, convertError))
-                goto continue_loop
-            end
-
-            local setSuccess, setError = pcall(function()
-                instance[propName] = convertedValue
-            end)
-
-            if setSuccess then
-                table.insert(appliedProperties, propName)
             else
-                table.insert(failedProperties, {
-                    name = propName,
-                    error = tostring(setError),
-                    value_tried = convertedValue
-                })
-                print(("SetProperties: Error setting property '%s' on instance '%s': %s"):format(propName, path, setError))
+                local setSuccess, setError = pcall(function()
+                    instance[propName] = convertedValue
+                end)
+
+                if setSuccess then
+                    table.insert(appliedProperties, propName)
+                else
+                    table.insert(failedProperties, {
+                        name = propName,
+                        error = tostring(setError),
+                        value_tried = convertedValue
+                    })
+                    print(("SetProperties: Error setting property '%s' on instance '%s': %s"):format(propName, path, setError))
+                end
             end
-            ::continue_loop::
         end
 
         if #failedProperties > 0 then


### PR DESCRIPTION
This commit is part of iteratively restoring functionality to the simplified RunCode.luau script.

Reintroduced:
- An `output_parts` table for collecting log messages.
- A simplified `addToOutput` helper function (using basic `tostring`).
- Overriding of `print`, `warn`, and `error` in the loaded chunk's environment to use the new `addToOutput`.

This step tests if the environment manipulation and basic output collection reintroduce the parsing error.