### PR TITLE
I've made several improvements to how I handle code and communicate r…

### DIFF
--- a/gemini_tools.py
+++ b/gemini_tools.py
@@ -1029,6 +1029,703 @@ class ToolDispatcher:
                         logger.error(f"Error parsing get_selection result: {e}")
                         output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error": str(e)}
                         ConsoleFormatter.print_tool_result(raw_mcp_result) # Or a specific error message
+                elif original_tool_name == "FindFirstChildMatching":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", ""),
+                           "parent_path": data.get("parent_path"),
+                           "child_name_searched": data.get("child_name_searched"),
+                           "recursive_search": data.get("recursive_search"),
+                           "child_found": bool(data.get("found_child_path")),
+                           "found_child_path": data.get("found_child_path"),
+                           "found_child_class_name": data.get("found_child_class_name")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "message": f"FindFirstChildMatching processed: {data.get('message', '')}"})
+                    except Exception as e:
+                        logger.error(f"Error parsing FindFirstChildMatching result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetChildrenOfInstance":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        children_list = data.get("children", [])
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Found {len(children_list)} children for {data.get('instance_path')}."),
+                           "instance_path": data.get("instance_path"),
+                           "children_count": len(children_list),
+                           "children": children_list
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "message": f"GetChildrenOfInstance processed for {data.get('instance_path')}"})
+                    except Exception as e:
+                        logger.error(f"Error parsing GetChildrenOfInstance result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetDescendantsOfInstance":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        descendants_list = data.get("descendants", [])
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Found {len(descendants_list)} descendants for {data.get('instance_path')}."),
+                           "instance_path": data.get("instance_path"),
+                           "descendants_count": len(descendants_list),
+                           "descendants": descendants_list
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "message": f"GetDescendantsOfInstance processed for {data.get('instance_path')}"})
+                    except Exception as e:
+                        logger.error(f"Error parsing GetDescendantsOfInstance result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetInstancesWithTag":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        instances_list = data.get("instances", [])
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Found {len(instances_list)} instances with tag '{data.get('tag_name')}'."),
+                           "tag_name": data.get("tag_name"),
+                           "instance_count": len(instances_list),
+                           "instances": instances_list
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "message": f"GetInstancesWithTag processed for tag {data.get('tag_name')}"})
+                    except Exception as e:
+                        logger.error(f"Error parsing GetInstancesWithTag result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "HasTag":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Tag '{data.get('tag_name')}' on '{data.get('instance_path')}' is {data.get('has_tag')}."),
+                           "instance_path": data.get("instance_path"),
+                           "tag_name": data.get("tag_name"),
+                           "has_tag": data.get("has_tag")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "message": f"HasTag processed for {data.get('instance_path')}"})
+                    except Exception as e:
+                        logger.error(f"Error parsing HasTag result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "CreateInstance":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "instance_path": data.get("instance_path"),
+                           "class_name": data.get("class_name")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "message": f"CreateInstance processed: {data.get('message')}"})
+                    except Exception as e:
+                        logger.error(f"Error parsing CreateInstance result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "DeleteInstance":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        path_not_found = data.get("path_not_found")
+                        output_content_dict = {
+                           "status": "success_instance_not_found" if path_not_found else "success",
+                           "tool_message": data.get("message"),
+                           "deleted_path": data.get("deleted_path"),
+                           "path_not_found": path_not_found
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "message": f"DeleteInstance processed: {data.get('message')}"})
+                    except Exception as e:
+                        logger.error(f"Error parsing DeleteInstance result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                # --- Start of new comprehensive handlers ---
+                elif original_tool_name in ["GetProperties", "GetInstanceProperties"]:
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Properties fetched for {data.get('instance_path')}."),
+                           "instance_path": data.get("instance_path"),
+                           "properties": data.get("properties"),
+                           "errors": data.get("errors")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": f"Properties fetched for {data.get('instance_path')}"})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetLightingProperty":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Lighting property {data.get('property_name')} fetched."),
+                           "property_name": data.get("property_name"),
+                           "value": data.get("value")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": f"Lighting property {data.get('property_name')} fetched."})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetWorkspaceProperty":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Workspace property {data.get('property_name')} fetched."),
+                           "property_name": data.get("property_name"),
+                           "value": data.get("value")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": f"Workspace property {data.get('property_name')} fetched."})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetMouseHitCFrame":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", "Mouse hit CFrame processed."),
+                           "instance_hit_path": data.get("instance_hit_path"),
+                           "position": data.get("position"),
+                           "cframe_components": data.get("cframe_components")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message", "Mouse hit CFrame processed.")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetMousePosition":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", "Mouse position fetched."),
+                           "x": data.get("x"),
+                           "y": data.get("y"),
+                           "viewport_size": data.get("viewport_size")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message", "Mouse position fetched.")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetPlayersInTeam":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        players_list = data.get("players", [])
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Players in team {data.get('team_name')} fetched."),
+                           "team_name": data.get("team_name"),
+                           "team_path": data.get("team_path"),
+                           "player_count": len(players_list),
+                           "players": players_list
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": f"Players in team {data.get('team_name')} fetched."})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetProductInfo":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Product info for asset ID {data.get('asset_id')} fetched."),
+                           "asset_id": data.get("asset_id"),
+                           "info_type_used": data.get("info_type_used"),
+                           "product_info": data.get("product_info")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": f"Product info for asset ID {data.get('asset_id')} fetched."})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetTeams":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", "Teams fetched."),
+                           "team_count": data.get("team_count"),
+                           "teams": data.get("teams")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message", "Teams fetched.")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "GetTeleportData":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", "Teleport data fetched."),
+                           "teleport_data": data.get("teleport_data"),
+                           "source_place_id": data.get("source_place_id")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message", "Teleport data fetched.")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "AddDebrisItem":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "instance_path": data.get("instance_path"),
+                           "lifetime": data.get("lifetime")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "AddTag":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "instance_path": data.get("instance_path"),
+                           "tag_name": data.get("tag_name")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "CallInstanceMethod":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "results": data.get("results")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "CreateGuiElement":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "element_path": data.get("element_path"),
+                           "element_type": data.get("element_type"),
+                           "parent_path_used": data.get("parent_path_used")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "CreateProximityPrompt":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "prompt_path": data.get("prompt_path"),
+                           "action_text": data.get("action_text"),
+                           "object_text": data.get("object_text"),
+                           "max_activation_distance": data.get("max_activation_distance")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "CreateTeam":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "team_name": data.get("team_name"),
+                           "team_color": data.get("team_color"),
+                           "auto_assignable": data.get("auto_assignable"),
+                           "team_path": data.get("team_path")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "CreateTextChannel":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "channel_name": data.get("channel_name"),
+                           "channel_path": data.get("channel_path")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "IncrementData":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "store_name": data.get("store_name"),
+                           "key": data.get("key"),
+                           "new_value": data.get("new_value"),
+                           "incremented_by": data.get("incremented_by")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "IsKeyDown":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "key_code_used": data.get("key_code_used"),
+                           "is_down": data.get("is_down")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "IsMouseButtonDown":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "mouse_button_checked": data.get("mouse_button_checked"),
+                           "is_down": data.get("is_down")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "KickPlayer":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "kicked_player_name": data.get("kicked_player_name"),
+                           "kick_message_used": data.get("kick_message_used")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "LoadAssetById":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "asset_path": data.get("asset_path"),
+                           "asset_id": data.get("asset_id"),
+                           "asset_class_name": data.get("asset_class_name")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "LoadData":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "store_name": data.get("store_name"),
+                           "key": data.get("key"),
+                           "data": data.get("data")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "PlaySoundId":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "sound_path": data.get("sound_path"),
+                           "sound_id": data.get("sound_id"),
+                           "is_playing": data.get("is_playing"),
+                           "duration": data.get("duration"),
+                           "details": data.get("details")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "PromptPurchase":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "player_name": data.get("player_name"),
+                           "asset_id": data.get("asset_id"),
+                           "purchase_type_prompted": data.get("purchase_type_prompted")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "RemoveData":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "store_name": data.get("store_name"),
+                           "key": data.get("key")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "RunScript": # Corresponds to CreateScriptResultData
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "script_path": data.get("script_path"),
+                           "script_type": data.get("script_type"),
+                           "initially_disabled": data.get("initially_disabled")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "SaveData":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "store_name": data.get("store_name"),
+                           "key": data.get("key")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "SelectInstances":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "selected_paths": data.get("selected_paths"),
+                           "selection_count": data.get("selection_count"),
+                           "errors_finding_paths": data.get("errors_finding_paths")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "SendChatMessage":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "message_sent": data.get("message_sent"),
+                           "channel_used": data.get("channel_used"),
+                           "speaker_used": data.get("speaker_used")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name in ["SetInstanceProperties", "SetProperties"]:
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "instance_path": data.get("instance_path"),
+                           "results": data.get("results") # List of PropertyWriteResult
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "SetLightingProperty":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Lighting property {data.get('property_name')} set."),
+                           "property_name": data.get("property_name"),
+                           "new_value_set": data.get("new_value_set")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": f"Lighting property {data.get('property_name')} set."})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "SetWorkspaceProperty":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", f"Workspace property {data.get('property_name')} set."),
+                           "property_name": data.get("property_name"),
+                           "new_value_set": data.get("new_value_set")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": f"Workspace property {data.get('property_name')} set."})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "TeleportPlayerToPlace": # This one might have a more complex Luau return
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str) # Assuming Luau returns a table with relevant fields
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message", "Teleport initiated."),
+                           "players_teleported_paths": data.get("players_teleported_paths"), # Example field
+                           "place_id": data.get("place_id"),
+                           "job_id": data.get("job_id"),
+                           "teleport_data_sent": data.get("teleport_data_sent")
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message", "Teleport initiated.")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                elif original_tool_name == "TweenProperties":
+                    try:
+                        parsed_outer = json.loads(raw_mcp_result)
+                        inner_json_str = parsed_outer["content"][0]["text"]
+                        data = json.loads(inner_json_str)
+                        output_content_dict = {
+                           "status": "success",
+                           "tool_message": data.get("message"),
+                           "instance_path": data.get("instance_path"),
+                           "duration": data.get("duration"),
+                           "easing_style_used": data.get("easing_style_used"),
+                           "easing_direction_used": data.get("easing_direction_used"),
+                           "properties_goal_summary": str(data.get("properties_goal")) # Keep it summarized
+                        }
+                        ConsoleFormatter.print_tool_result({"status": "success", "tool_name": original_tool_name, "processed_message": data.get("message")})
+                    except Exception as e:
+                        logger.error(f"Error parsing {original_tool_name} result: {e}")
+                        output_content_dict = {"status": "success", "output": raw_mcp_result, "parsing_error_in_python": str(e)}
+                        ConsoleFormatter.print_tool_result(raw_mcp_result)
+                # --- End of new comprehensive handlers ---
                 else:
                     # For other tools, keep original behavior
                     output_content_dict = {"status": "success", "output": raw_mcp_result}

--- a/plugin/src/Tools/InsertModel.luau
+++ b/plugin/src/Tools/InsertModel.luau
@@ -151,12 +151,10 @@ end
 local function handleInsertModel(args: Types.InsertModelArgs)
     local success, resultOrError = pcall(function()
         if type(args.query) ~= "string" or string.len(args.query) == 0 then
-
             return { __isError = true, message = "InsertModel: 'query' argument (asset ID or search term) is missing, empty, or not a string." }
         end
         if args.parent_path and type(args.parent_path) ~= "string" then
             return { __isError = true, message = "InsertModel: 'parent_path', if provided, must be a string." }
-
         end
 
         return performInsert(args.query, args.parent_path) -- This returns (data, errorString) or (nil, errorString)


### PR DESCRIPTION
…esults.

**Luau Changes:**

1.  **Restored Helper Files**:
    - `plugin/src/Types.luau` and `plugin/src/ToolHelpers.luau` are now back to their full, original versions, fixing an accidental overwrite.

2.  **`plugin/src/Tools/RunCode.luau` Syntax Fix**:
    - I've confirmed that the newline character after a `for` loop's `end` statement is fixed, which resolves a parsing error.

3.  **`plugin/src/Tools/InsertModel.luau` Syntax Fix (Table Error Return)**:
    - To fix a persistent "Ambiguous syntax" error, if there's an issue with arguments, I now return a table like `{ __isError = true, message = "..." }`. I've updated the logic in `handleInsertModel` to correctly process this or the success/error information from `performInsert`. This is my latest attempt to ensure `InsertModel.luau` loads correctly.

4.  **`get_selection.luau` Case Sensitivity Fix**:
    - I've renamed `plugin/src/Tools/GetSelection.luau` to `plugin/src/Tools/get_selection.luau`. This makes its filename match its definition and how it's used, which should resolve "tool not found" errors.

**Python Changes (`gemini_tools.py`):**

1.  **Improved `get_selection` Empty Result Handling**:
    - When I execute `get_selection`, I now specifically check the result. If nothing is selected, I'll provide a clear and simple response (e.g., `{"status": "success", "message": "No instances are currently selected...", "selection_empty": True}`). This should prevent misinterpretations and unwanted follow-up actions, which helps avoid API rate limit issues.

2.  **Comprehensive Response Simplification for Most Luau Tools**:
    - For many other Luau tools (like various "Getters" such as `FindFirstChildMatching`, `GetChildrenOfInstance`, `GetInstanceProperties`, and "Action/Creator" tools like `CreateInstance`, `DeleteInstance`, `SetInstanceProperties`, `AddTag`, `PlaySoundId`, etc.), I've added specific logic to how I handle their execution.
    - This new logic parses the nested JSON response string from the Luau tools.
    - Then, I extract the main data and create a simpler, more direct dictionary to understand. This includes:
        - A general `"status": "success"`.
        - A `"tool_message"` field based on the Luau tool's message. - Tool-specific data fields (e.g., `instance_path`, `children_count`, `has_tag`, `properties`, `errors` list for partial failures).
    - I'm using robust `try-except` blocks during this parsing. If parsing on my end fails, I'll fall back to using the raw result to ensure no data is lost and errors are logged.

These widespread changes should significantly improve the reliability of Luau operations and the clarity of the results I get, leading to more accurate and efficient behavior when I'm working with your code.