### PR TITLE
Fix: Correct Luau tool script errors and improve error handling

### DIFF
--- a/plugin/src/Tools/CreateInstance.luau
+++ b/plugin/src/Tools/CreateInstance.luau
@@ -7,7 +7,7 @@ local function execute(args: Types.CreateInstanceArgs) -- Type annotation added
     local success, resultOrError = pcall(function()
         local className = args.class_name
         local properties = args.properties or {} -- Default to empty table
-        local parentPath = args.parent_path -- Use parent_path from args
+        local arg_parent_path = args.parent_path -- Store original arg
 
         if not className or type(className) ~= "string" then
             return "'class_name' is required and must be a string." -- Return error string
@@ -26,26 +26,40 @@ local function execute(args: Types.CreateInstanceArgs) -- Type annotation added
         local propertyErrors = {}
         local parentInstance = nil
 
-        -- Handle Parent explicitly from parent_path argument
-        if parentPath then
-            if type(parentPath) == "string" then
-                local foundParent, err = ToolHelpers.FindInstanceByPath(parentPath)
-                if foundParent then
-                    parentInstance = foundParent
-                else
-                    newInstance:Destroy() -- Clean up partially created instance
-                    return ("Failed to find specified Parent at path: %s. %s"):format(parentPath, err or "Unknown error") -- Return error string
-                end
+        -- Determine parent:
+        -- 1. Prioritize explicit parent_path argument from args.
+        -- 2. Fallback to properties.Parent if args.parent_path is not provided.
+        local effectiveParentPath = arg_parent_path
+        if not effectiveParentPath and properties.Parent then
+            if type(properties.Parent) == "string" then
+                effectiveParentPath = properties.Parent
             else
-                -- This case should ideally be caught by type checking if parent_path is strictly string
-                newInstance:Destroy()
-                return ("'parent_path' property, if provided, must be a string path. Got type: %s"):format(typeof(parentPath)) -- Return error string
+                newInstance:Destroy() -- Clean up
+                return ("'Parent' property in 'properties' table must be a string path. Got type: %s"):format(typeof(properties.Parent))
             end
         end
 
-        -- Apply other properties (ensure "Parent" is not processed again if it was in properties)
+        if effectiveParentPath then
+            -- This check is a bit redundant now if properties.Parent has been type-checked, but good for safety
+            if type(effectiveParentPath) == "string" then
+                local foundParent, err = ToolHelpers.FindInstanceByPath(effectiveParentPath)
+                if foundParent then
+                    parentInstance = foundParent
+                else
+                    newInstance:Destroy() -- Clean up
+                    return ("Failed to find specified Parent at path: %s. %s"):format(effectiveParentPath, err or "Unknown error")
+                end
+            else
+                newInstance:Destroy() -- Clean up
+                -- This case should ideally not be reached if the logic above is correct
+                return ("Internal Error: Effective parent path resolved to a non-string. Path: %s"):format(tostring(effectiveParentPath))
+            end
+        end
+
+        -- Apply other properties
         for propName, propValueInput in pairs(properties) do
-            if string.lower(propName) ~= "parent" then -- Avoid processing Parent if it was also in properties
+            local propNameLower = string.lower(propName)
+            if propNameLower ~= "parent" then -- Parent is now fully handled by parentInstance logic above
                 local convertedValue, convertError = ToolHelpers.JsonToRobloxValue(propValueInput, newInstance.ClassName.."."..propName)
                 if convertError then
                     table.insert(propertyErrors, ("Property '%s': Failed to convert input value: %s"):format(propName, convertError))
@@ -79,10 +93,15 @@ local function execute(args: Types.CreateInstanceArgs) -- Type annotation added
     end)
 
     if success then
-        -- Pass the XXXResultData to FormatSuccessResult
-        return ToolHelpers.FormatSuccessResult(resultOrError)
+		if type(resultOrError) == "string" then -- An error message string was returned
+			return ToolHelpers.FormatErrorResult(resultOrError)
+		elseif resultOrError == nil then -- pcall succeeded but function returned nil (shouldn't happen with current logic but good to cover)
+			return ToolHelpers.FormatErrorResult("CreateInstance returned nil unexpectedly.")
+		else -- A resultData table was returned
+			return ToolHelpers.FormatSuccessResult(resultOrError)
+		end
     else
-        -- Pass the error message string to FormatErrorResult
+		-- pcall itself failed
         return ToolHelpers.FormatErrorResult("Internal error in CreateInstance: " .. tostring(resultOrError))
     end
 end

--- a/plugin/src/Tools/GetInstanceProperties.luau
+++ b/plugin/src/Tools/GetInstanceProperties.luau
@@ -127,7 +127,7 @@ local function execute(args: Types.GetInstancePropertiesArgs)
 			message = message .. (" Encountered %d errors retrieving some requested properties."):format(ToolHelpers.TableLength(accessErrors))
 		end
 
-		local resultData = { -- MODIFIED LINE: Removed type annotation
+		local resultData = {
 			message = message,
 			instance_path = path,
 			properties = retrievedProperties,

--- a/plugin/src/Tools/GetLightingProperty.luau
+++ b/plugin/src/Tools/GetLightingProperty.luau
@@ -33,12 +33,15 @@ local function execute(args: Types.GetLightingPropertyArgs) -- Type annotation a
     end)
 
     if success then
-        if type(resultOrError) == "string" then
+		if type(resultOrError) == "string" then -- An error message string was returned
             return ToolHelpers.FormatErrorResult(resultOrError)
-        else
+		elseif resultOrError == nil then
+			return ToolHelpers.FormatErrorResult("GetLightingProperty returned nil unexpectedly.")
+		else -- A resultData table was returned
             return ToolHelpers.FormatSuccessResult(resultOrError)
         end
     else
+		-- pcall itself failed
         return ToolHelpers.FormatErrorResult("Internal error in GetLightingProperty: " .. tostring(resultOrError))
     end
 end

--- a/plugin/src/Tools/InsertModel.luau
+++ b/plugin/src/Tools/InsertModel.luau
@@ -163,7 +163,7 @@ local function handleInsertModel(args: Types.InsertModelArgs)
     if pcall_ok then
         -- Check if the pcall'd function returned our custom error table (e.g. from arg validation)
         if primary_return and primary_return.__isError then
-            return ToolHelpers.FormatErrorResult(primary_return.message); -- MODIFIED LINE
+            return ToolHelpers.FormatErrorResult(primary_return.message) -- MODIFIED LINE
         else
             -- If not a custom error, then primary_return is the first value from performInsert (data or nil)
             -- and secondary_return is the second value from performInsert (errorString or nil)

--- a/plugin/src/Tools/delete_instance.luau
+++ b/plugin/src/Tools/delete_instance.luau
@@ -40,12 +40,17 @@ local function execute(args: Types.DeleteInstanceArgs) -- Type annotation added
     end)
 
     if success then
-        if type(resultOrError) == "string" then -- Error string returned from pcall function
+		if type(resultOrError) == "string" then -- An error message string was returned
             return ToolHelpers.FormatErrorResult(resultOrError)
-        else -- Data table returned
+		elseif resultOrError == nil then
+			return ToolHelpers.FormatErrorResult("delete_instance returned nil unexpectedly.")
+		else -- A resultData table was returned
+			-- Check if the returned table is one of the "path_not_found" custom success payloads
+			-- or a genuine success payload. Both should be handled by FormatSuccessResult.
             return ToolHelpers.FormatSuccessResult(resultOrError)
         end
     else
+		-- pcall itself failed
         return ToolHelpers.FormatErrorResult("Internal error in DeleteInstance: " .. tostring(resultOrError))
     end
 end


### PR DESCRIPTION
This commit addresses several issues I identified from test sequence logs:

1.  **Syntax Errors in Tool Scripts:**
    -   `GetInstanceProperties.luau`: I fixed an "Incomplete statement" error by removing a misplaced comment within a table constructor.
    -   `InsertModel.luau`: I fixed an "Ambiguous syntax" error by removing a trailing semicolon.
    These fixes ensure the respective tools are correctly loaded by the main plugin script.

2.  **Tool Timeouts due to Unhandled Errors:**
    -   I modified `CreateInstance.luau`, `GetLightingProperty.luau`, and `delete_instance.luau`.
    -   I ensured that if the main `pcall`'s protected function returns an error string (due to argument validation or internal API call failures), this string is correctly passed to `ToolHelpers.FormatErrorResult`. Previously, such strings could be passed to `ToolHelpers.FormatSuccessResult`, causing a secondary unhandled error within the helper and preventing any response from being sent, leading to a timeout.

3.  **`SelectInstances` Failure:**
    -   I updated `CreateInstance.luau` to correctly use the `Parent` value from the `properties` table if `args.parent_path` is not explicitly provided. This ensures instances are parented to the intended location (e.g., `Workspace`), allowing `SelectInstances` to find them.

These changes should improve the reliability and success rate of the Luau tools executed.