### PR TITLE
I've addressed some Luau syntax errors and a tool name casing issue.

### DIFF
--- a/gemini_tools.py
+++ b/gemini_tools.py
@@ -984,13 +984,17 @@ class ToolDispatcher:
             mcp_tool_name = "execute_discovered_luau_tool"
             # Serialize original_tool_args into a JSON string
             tool_arguments_json_str = json.dumps(original_tool_args)
+            luau_tool_name_to_execute = original_tool_name
+            if original_tool_name == "set_instance_properties":
+                luau_tool_name_to_execute = "SetInstanceProperties"
+            # Add other mappings here if needed in the future
             mcp_tool_args = {
-                "tool_name": original_tool_name,
-                "tool_arguments_str": tool_arguments_json_str # Correct field name and value type
+                "tool_name": luau_tool_name_to_execute, # Use the potentially corrected name
+                "tool_arguments_str": tool_arguments_json_str
             }
             # Update logger message to reflect the change if desired, or keep as is if original_tool_args is fine for logging.
             # For clarity in logs, let's log what's actually being prepared for MCP:
-            logger.info(f"Dispatching ToolCall: '{original_tool_name}' via MCP tool '{mcp_tool_name}' for Luau script '{original_tool_name}'. Luau script args (as JSON string): {tool_arguments_json_str}")
+            logger.info(f"Dispatching ToolCall: '{original_tool_name}' via MCP tool '{mcp_tool_name}' for Luau script '{luau_tool_name_to_execute}'. Luau script args (as JSON string): {tool_arguments_json_str}")
 
         output_content_dict = {}
         try:

--- a/plugin/src/Tools/GetInstanceProperties.luau
+++ b/plugin/src/Tools/GetInstanceProperties.luau
@@ -136,7 +136,7 @@ local function execute(args: Types.GetInstancePropertiesArgs)
 			resultData.errors = accessErrors
 		end
 
-		return resultData -- Removed semicolon and trailing comment
+		return resultData
 
 	end)
 
@@ -152,7 +152,7 @@ local function execute(args: Types.GetInstancePropertiesArgs)
 			message = "Internal script error in GetInstanceProperties: " .. tostring(resultOrError),
 			instance_path = args.path or "nil",
 			properties = {},
-			errors = { internal_error = tostring(resultOrRrror) }, -- Potential typo here: resultOrRrror should likely be resultOrError
+			errors = { internal_error = tostring(resultOrError) }, -- Potential typo here: resultOrRrror should likely be resultOrError
 		})
 	end
 end

--- a/plugin/src/Tools/InsertModel.luau
+++ b/plugin/src/Tools/InsertModel.luau
@@ -171,7 +171,7 @@ local function handleInsertModel(args: Types.InsertModelArgs)
                 return ToolHelpers.FormatErrorResult(secondary_return)
             else -- No errorString from performInsert, so primary_return should be valid data
 
-                return ToolHelpers.FormatSuccessResult(primary_return)
+                return (ToolHelpers.FormatSuccessResult(primary_return))
 
             end
         end


### PR DESCRIPTION
- I corrected a typo in GetInstanceProperties.luau that likely caused a syntax error.
- I resolved an ambiguous syntax error in InsertModel.luau by parenthesizing a return statement.
- I reviewed all other Luau tools for syntax issues.
- I fixed a case mismatch in gemini_tools.py for the 'SetInstanceProperties' tool, ensuring the correct casing is sent to the MCP server.

These changes aim to resolve Luau script loading issues, the 'tool not found' error for SetInstanceProperties, and subsequent command timeouts.