### PR TITLE
Fix: Correct Luau script loading errors and execution timeouts

### DIFF
--- a/plugin/src/Tools/GetInstanceProperties.luau
+++ b/plugin/src/Tools/GetInstanceProperties.luau
@@ -30,7 +30,6 @@ local function execute(args: Types.GetInstancePropertiesArgs)
 		local retrievedProperties: { [string]: any } = {}
 		local accessErrors: { [string]: string } = {} -- Changed to dictionary for easier property-specific errors
 
-		-- [[ -- Start of large comment
 		local fetchAllProperties = false
 		if propertyNamesInput == nil or (type(propertyNamesInput) == "table" and #propertyNamesInput == 0) then
 			fetchAllProperties = true
@@ -93,7 +92,7 @@ local function execute(args: Types.GetInstancePropertiesArgs)
 					retrievedProperties[propNameString] = ToolHelpers.SerializeValue(propValue)
 				else
 					-- Silently ignore errors when fetching all, or add to errors if desired
-					-- accessErrors[propNameString] = "Error fetching property: " .. tostring(propValue)
+					accessErrors[propNameString] = "Error fetching property: " .. tostring(propValue)
 				end
 			end
 			if #accessErrors == 0 then -- Check if accessErrors is empty using #
@@ -122,22 +121,21 @@ local function execute(args: Types.GetInstancePropertiesArgs)
 				accessErrors = nil -- Set to nil if no errors
 			end
 		end
-		-- ]] -- End of large comment
 
 
 		local messageText = ("Successfully retrieved %d properties for instance '%s'."):format(ToolHelpers.TableLength(retrievedProperties), path)
-		-- if accessErrors then -- Keep this commented out for now
-		--	messageText = messageText .. (" Encountered %d errors retrieving some requested properties."):format(ToolHelpers.TableLength(accessErrors))
-		-- end
+		if accessErrors then
+			messageText = messageText .. (" Encountered %d errors retrieving some requested properties."):format(ToolHelpers.TableLength(accessErrors))
+		end
 
 		local dataToReturn = {
 			message = messageText,
 			instance_path = path,
 			properties = retrievedProperties, -- retrievedProperties will be {} if main logic was previously commented
 		}
-		-- if accessErrors then -- Keep this commented out for now
-		--	dataToReturn.errors = accessErrors
-		-- end
+		if accessErrors then
+			dataToReturn.errors = accessErrors
+		end
 
 		return dataToReturn
 

--- a/plugin/src/Tools/InsertModel.luau
+++ b/plugin/src/Tools/InsertModel.luau
@@ -149,6 +149,8 @@ local function performInsert(query: string, parentPath: string?): (Types.InsertM
 end
 
 local function handleInsertModel(args: Types.InsertModelArgs)
+    local result
+
     local pcall_ok, primary_return, secondary_return = pcall(function()
         if type(args.query) ~= "string" or string.len(args.query) == 0 then
             return { __isError = true, message = "InsertModel: 'query' argument (asset ID or search term) is missing, empty, or not a string." }
@@ -163,22 +165,26 @@ local function handleInsertModel(args: Types.InsertModelArgs)
     if pcall_ok then
         -- Check if the pcall'd function returned our custom error table (e.g. from arg validation)
         if primary_return and primary_return.__isError then
-            return ToolHelpers.FormatErrorResult(primary_return.message) -- MODIFIED LINE
+            result = ToolHelpers.FormatErrorResult(primary_return.message)
         else
             -- If not a custom error, then primary_return is the first value from performInsert (data or nil)
             -- and secondary_return is the second value from performInsert (errorString or nil)
             if secondary_return then -- This is the errorString from performInsert
-                return ToolHelpers.FormatErrorResult(secondary_return);
+                result = ToolHelpers.FormatErrorResult(secondary_return)
             else -- No errorString from performInsert, so primary_return should be valid data
-
-                return ToolHelpers.FormatSuccessResult(primary_return)
-
+                if primary_return then
+                    result = ToolHelpers.FormatSuccessResult(primary_return)
+                else
+                    -- This case implies performInsert returned (nil, nil) which is unexpected.
+                    result = ToolHelpers.FormatErrorResult("InsertModel: performInsert returned no data and no error.")
+                end
             end
         end
     else
         -- pcall itself failed, primary_return contains the error message from pcall
-        return ToolHelpers.FormatErrorResult("Internal pcall error in InsertModel: " .. tostring(primary_return))
+        result = ToolHelpers.FormatErrorResult("Internal pcall error in InsertModel: " .. tostring(primary_return))
     end
+    return result
 end
 
 return handleInsertModel

--- a/plugin/src/Tools/delete_instance.luau
+++ b/plugin/src/Tools/delete_instance.luau
@@ -39,20 +39,23 @@ local function execute(args: Types.DeleteInstanceArgs) -- Type annotation added
         return resultData
     end)
 
+    local finalResult
     if success then
-		if type(resultOrError) == "string" then -- An error message string was returned
-            return ToolHelpers.FormatErrorResult(resultOrError)
-		elseif resultOrError == nil then
-			return ToolHelpers.FormatErrorResult("delete_instance returned nil unexpectedly.")
-		else -- A resultData table was returned
-			-- Check if the returned table is one of the "path_not_found" custom success payloads
-			-- or a genuine success payload. Both should be handled by FormatSuccessResult.
-            return ToolHelpers.FormatSuccessResult(resultOrError)
+		if type(resultOrError) == "string" then -- An error message string was returned from the pcall'd function
+            finalResult = ToolHelpers.FormatErrorResult(resultOrError)
+		elseif type(resultOrError) == "table" then -- A resultData table was returned from the pcall'd function
+			-- This handles both genuine success payloads and "path_not_found" custom payloads.
+            finalResult = ToolHelpers.FormatSuccessResult(resultOrError)
+		elseif resultOrError == nil then -- Should ideally not be reached if pcall'd function always returns a value
+			finalResult = ToolHelpers.FormatErrorResult("DeleteInstance: pcall succeeded but returned nil unexpectedly.")
+		else -- Catch any other unexpected types returned by the pcall'd function
+			finalResult = ToolHelpers.FormatErrorResult("DeleteInstance: Unexpected result type from pcall: " .. type(resultOrError))
         end
     else
 		-- pcall itself failed
-        return ToolHelpers.FormatErrorResult("Internal error in DeleteInstance: " .. tostring(resultOrError))
+        finalResult = ToolHelpers.FormatErrorResult("Internal error in DeleteInstance: " .. tostring(resultOrError))
     end
+    return finalResult
 end
 
 return execute


### PR DESCRIPTION
This commit addresses several issues identified in the Luau scripts:

1.  **GetInstanceProperties.luau:**
    *   Uncommented the main property-fetching logic, which was causing the script to do nothing and likely leading to timeouts.
    *   Uncommented error reporting for `messageText` and `dataToReturn` to provide more diagnostic information.

2.  **InsertModel.luau:**
    *   Resolved an "Ambiguous syntax" error. The initial fix involved adding semicolons.
    *   Further refactored the conditional return logic in `handleInsertModel` to assign results to a local variable before returning. This improves clarity and robustly prevents the syntax ambiguity.

3.  **delete_instance.luau:**
    *   Reviewed and refined the script for robustness.
    *   Refactored the conditional return logic in the `execute` function (similar to `InsertModel.luau`) to assign results to a local variable first, enhancing clarity and consistency.

These changes aim to resolve script loading failures, execution timeouts, and improve the overall stability and maintainability of the affected Luau scripts.