### PR TITLE
Fix: Correct Luau syntax errors and address related timeout

### DIFF
--- a/plugin/src/Tools/GetInstanceProperties.luau
+++ b/plugin/src/Tools/GetInstanceProperties.luau
@@ -101,21 +101,19 @@ local function execute(args: Types.GetInstancePropertiesArgs)
 
 		else -- Specific property names were provided
 			for _, propNameString in ipairs(propertyNamesInput) do
-				if type(propNameString) ~= "string" then
-					accessErrors[tostring(#accessErrors + 1)] = ("All 'property_names' must be strings. Found entry with type: %s"):format(type(propNameString))
-					goto continueLoop -- Skips to next iteration using goto
-				end
+				if type(propNameString) == "string" then
+					local getSuccess, propValue = pcall(function()
+						return instance[propNameString]
+					end)
 
-				local getSuccess, propValue = pcall(function()
-					return instance[propNameString]
-				end)
-
-				if getSuccess then
-					retrievedProperties[propNameString] = ToolHelpers.SerializeValue(propValue)
+					if getSuccess then
+						retrievedProperties[propNameString] = ToolHelpers.SerializeValue(propValue)
+					else
+						accessErrors[propNameString] = "Error getting property: " .. tostring(propValue)
+					end
 				else
-					accessErrors[propNameString] = "Error getting property: " .. tostring(propValue)
+					accessErrors[tostring(#accessErrors + 1)] = ("All 'property_names' must be strings. Found entry with type: %s"):format(type(propNameString))
 				end
-				::continueLoop::
 			end
 			if #accessErrors == 0 then -- Check if accessErrors is empty using #
 				accessErrors = nil -- Set to nil if no errors

--- a/plugin/src/Tools/InsertModel.luau
+++ b/plugin/src/Tools/InsertModel.luau
@@ -33,7 +33,7 @@ local function toTitleCase(str: string): string
 	local function titleCase(first: string, rest: string)
 		return first:upper() .. rest:lower()
 	end
-	local intermediate = string.gsub(str, "(%a)([%w_']*)", titleCase :: (string) -> string)
+	local intermediate = string.gsub(str, "(%a)([%w_']*)", titleCase)
 	return intermediate:gsub("%s+", "")
 end
 


### PR DESCRIPTION
This commit addresses specific Luau syntax errors identified in the Roblox plugin tools:

1.  **GetInstanceProperties.luau:**
    *   Removed a `goto continueLoop` statement and its corresponding
        `::continueLoop::` label. The loop logic was refactored to
        achieve the same control flow without using `goto`.
    *   This change is expected to resolve the "Incomplete statement:
        expected assignment or a function call" error on line 106.
    *   This is also expected to resolve the 20-second timeout and the
        "Client that was waiting for task is gone" error for this tool,
        as the syntax error likely prevented the script from executing.

2.  **InsertModel.luau:**
    *   Removed a type cast `:: (string) -> string` from the `titleCase`
        function when it was passed as an argument to `string.gsub`.
        The line was changed from:
        `local intermediate = string.gsub(str, "(%a)([%w_']*)", titleCase :: (string) -> string)`
        to:
        `local intermediate = string.gsub(str, "(%a)([%w_']*)", titleCase)`
    *   This change is expected to resolve the "Ambiguous syntax" error.

A review of 20 other Luau tool files did not reveal further systemic instances of these particular syntax issues. You will compile and test these changes in your Roblox Studio environment.