### PR TITLE
Fix: Attempt to make MCP server send Luau strings and correct InsertM…

### DIFF
--- a/src/rbx_studio_server.rs
+++ b/src/rbx_studio_server.rs
@@ -242,17 +242,17 @@ fn format_tool_argument_values_to_luau_string(args: &ToolArgumentValues) -> Stri
     match args {
         ToolArgumentValues::ExecuteLuauByName { tool_name, arguments_luau } => {
             // Escape backslashes and then quotes for arguments_luau
-            let escaped_arguments_luau = arguments_luau.replace('\', "\\\\").replace('"', "\\\"");
+            let escaped_arguments_luau = arguments_luau.replace('\\', "\\\\").replace('"', "\\\"");
             format!("ExecuteLuauByName = {{ tool_name = \"{}\", arguments_luau = \"{}\" }}",
                     tool_name, escaped_arguments_luau)
         }
         ToolArgumentValues::RunCommand { command } => {
-            let escaped_command = command.replace('\', "\\\\").replace('"', "\\\"");
+            let escaped_command = command.replace('\\', "\\\\").replace('"', "\\\"");
             format!("RunCommand = {{ command = \"{}\" }}", escaped_command)
         }
         ToolArgumentValues::InsertModel { query } => {
             // Query for InsertModel is typically simpler, but escape for robustness.
-            let escaped_query = query.replace('\', "\\\\").replace('"', "\\\"");
+            let escaped_query = query.replace('\\', "\\\\").replace('"', "\\\"");
             format!("InsertModel = {{ query = \"{}\" }}", escaped_query)
         }
     }


### PR DESCRIPTION
…odel syntax

- Modified the Rust MCP server (`src/rbx_studio_server.rs`) to serialize tasks sent to the Luau plugin as executable Luau strings instead of JSON. The `request_handler` now uses a `to_luau_string()` method and sets `Content-Type` to `application/luau`.

- Corrected Rust syntax for character literals in string replace calls within the Luau serialization logic. Note: The precise escaping logic for backslashes and quotes within these replace calls proved difficult to achieve and may require your manual verification to ensure perfect Luau string literal compatibility if issues persist with special characters in arguments. The code should now compile.

- Verified that the existing `loadstring(message)` logic in the Luau plugin (`plugin/src/Main.server.luau`) is appropriate for the intended Luau string message format.

- Ensured a minor syntax ambiguity in `plugin/src/Tools/InsertModel.luau` (parentheses around a `tostring()` call) is corrected.