### PR TITLE
Refactor Luau tools to use centralized service access via ToolHelpers

### DIFF
--- a/plugin/src/Main.server.luau
+++ b/plugin/src/Main.server.luau
@@ -3,6 +3,36 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 
+-- Initialize ToolHelpers with Roblox services
+local robloxServices = {
+    Game = game,
+    Workspace = game:GetService("Workspace"),
+    Players = game:GetService("Players"),
+    ReplicatedStorage = game:GetService("ReplicatedStorage"),
+    ServerStorage = game:GetService("ServerStorage"),
+    Lighting = game:GetService("Lighting"),
+    StarterGui = game:GetService("StarterGui"),
+    StarterPlayer = game:GetService("StarterPlayer"),
+    Teams = game:GetService("Teams"),
+    TextChatService = game:GetService("TextChatService"),
+    ServerScriptService = game:GetService("ServerScriptService"),
+    SoundService = game:GetService("SoundService"),
+    StarterPack = game:GetService("StarterPack"),
+    UserInputService = game:GetService("UserInputService"),
+    DebrisService = game:GetService("Debris"),
+    CollectionService = game:GetService("CollectionService"),
+    PathfindingService = game:GetService("PathfindingService"),
+    TextService = game:GetService("TextService"),
+    MarketplaceService = game:GetService("MarketplaceService"),
+    DataStoreService = game:GetService("DataStoreService"),
+    InsertService = game:GetService("InsertService"),
+    Selection = game:GetService("Selection"),
+    -- Workspace, Lighting, UserInputService, SoundService are already confirmed to be present
+    TeleportService = game:GetService("TeleportService"),
+    TweenService = game:GetService("TweenService")
+}
+ToolHelpers.InitServices(robloxServices)
+
 local ChangeHistoryService = game:GetService("ChangeHistoryService")
 local HttpService = game:GetService("HttpService")
 local RunService = game:GetService("RunService")

--- a/plugin/src/ToolHelpers.luau
+++ b/plugin/src/ToolHelpers.luau
@@ -1,7 +1,90 @@
 -- ToolHelpers.luau
 local ToolHelpers = {}
 
+local _services = {}
 local HttpService = game:GetService("HttpService")
+
+function ToolHelpers.InitServices(servicesTable)
+	if type(servicesTable) ~= "table" then
+		warn("ToolHelpers.InitServices expects a table, got: " .. type(servicesTable))
+		return
+	end
+	for serviceName, serviceInstance in pairs(servicesTable) do
+		_services[serviceName] = serviceInstance
+	end
+end
+
+function ToolHelpers.GetDebrisService()
+	return _services.DebrisService
+end
+
+function ToolHelpers.GetCollectionService()
+	return _services.CollectionService
+end
+
+function ToolHelpers.GetPathfindingService()
+	return _services.PathfindingService
+end
+
+function ToolHelpers.GetTextService()
+	return _services.TextService
+end
+
+function ToolHelpers.GetPlayersService()
+	return _services.Players
+end
+
+function ToolHelpers.GetStarterGuiService()
+	return _services.StarterGui
+end
+
+function ToolHelpers.GetTeamsService()
+	return _services.Teams
+end
+
+function ToolHelpers.GetTextChatService()
+	return _services.TextChatService
+end
+
+function ToolHelpers.GetLightingService()
+	return _services.Lighting
+end
+
+function ToolHelpers.GetUserInputService()
+	return _services.UserInputService
+end
+
+function ToolHelpers.GetMarketplaceService()
+	return _services.MarketplaceService
+end
+
+function ToolHelpers.GetDataStoreService()
+	return _services.DataStoreService
+end
+
+function ToolHelpers.GetInsertService()
+	return _services.InsertService
+end
+
+function ToolHelpers.GetSelectionService()
+	return _services.Selection
+end
+
+function ToolHelpers.GetWorkspaceService()
+	return _services.Workspace
+end
+
+function ToolHelpers.GetSoundService()
+	return _services.SoundService
+end
+
+function ToolHelpers.GetTeleportService()
+	return _services.TeleportService
+end
+
+function ToolHelpers.GetTweenService()
+	return _services.TweenService
+end
 
 function ToolHelpers.FindInstanceByPath(pathString)
     if not pathString or type(pathString) ~= "string" or pathString == "" then
@@ -9,27 +92,27 @@ function ToolHelpers.FindInstanceByPath(pathString)
     end
 
     local lowerPath = string.lower(pathString)
-    if lowerPath == "workspace" then return workspace, nil end
-    if lowerPath == "lighting" then return game:GetService("Lighting"), nil end
-    if lowerPath == "soundservice" then return game:GetService("SoundService"), nil end
-    if lowerPath == "replicatedstorage" then return game:GetService("ReplicatedStorage"), nil end
-    if lowerPath == "serverstorage" then return game:GetService("ServerStorage"), nil end
-    if lowerPath == "serverplayers" or lowerPath == "players" then return game:GetService("Players"), nil end
-    if lowerPath == "starterplayer" then return game:GetService("StarterPlayer"), nil end
-    if lowerPath == "starterplayerscripts" then return game:GetService("StarterPlayer").StarterPlayerScripts, nil end
-    if lowerPath == "startercharacterscripts" then return game:GetService("StarterPlayer").StarterCharacterScripts, nil end
-    if lowerPath == "startergui" then return game:GetService("StarterGui"), nil end
-    if lowerPath == "starterpack" then return game:GetService("StarterPack"), nil end
-    if lowerPath == "serverscriptservice" then return game:GetService("ServerScriptService"), nil end
-    if lowerPath == "teams" then return game:GetService("Teams"), nil end
-    if lowerPath == "textchatservice" then return game:GetService("TextChatService"), nil end
-    if lowerPath == "userinputservice" then return game:GetService("UserInputService"), nil end
+    if lowerPath == "workspace" then return _services.Workspace, nil end
+    if lowerPath == "lighting" then return _services.Lighting, nil end
+    if lowerPath == "soundservice" then return _services.SoundService, nil end
+    if lowerPath == "replicatedstorage" then return _services.ReplicatedStorage, nil end
+    if lowerPath == "serverstorage" then return _services.ServerStorage, nil end
+    if lowerPath == "serverplayers" or lowerPath == "players" then return _services.Players, nil end
+    if lowerPath == "starterplayer" then return _services.StarterPlayer, nil end
+    if lowerPath == "starterplayerscripts" then return _services.StarterPlayer.StarterPlayerScripts, nil end
+    if lowerPath == "startercharacterscripts" then return _services.StarterPlayer.StarterCharacterScripts, nil end
+    if lowerPath == "startergui" then return _services.StarterGui, nil end
+    if lowerPath == "starterpack" then return _services.StarterPack, nil end
+    if lowerPath == "serverscriptservice" then return _services.ServerScriptService, nil end
+    if lowerPath == "teams" then return _services.Teams, nil end
+    if lowerPath == "textchatservice" then return _services.TextChatService, nil end
+    if lowerPath == "userinputservice" then return _services.UserInputService, nil end
      -- Path for PlayerGui typically needs player name, e.g. "Players.LocalPlayer.PlayerGui"
     -- However, if just "PlayerGui" is passed for a ScreenGui, some tools might try to resolve LocalPlayer.PlayerGui.
     -- For direct access, a full path is better. This helper won't assume LocalPlayer here.
 
 
-    local current = game
+    local current = _services.Game
     for part in string.gmatch(pathString, "[^%.]+") do
         if not current or typeof(current) ~= "Instance" then
              return nil, "Invalid path segment: " .. part .. " - parent is not an Instance or nil."
@@ -398,7 +481,7 @@ function ToolHelpers.ConvertTableToRobloxType(inputTable, propertyName, instance
             else
                 return inputTable, "Invalid 'material_enum_name': " .. (err or "must be a valid Enum.Material string (e.g., 'Enum.Material.Plastic').")
             end
-        elseif inputTable.density ~= nil or inputTable.friction ~= nil or inputTable.elasticity ~= nil then -- Allow partial for custom
+        elseif inputTable.density ~= nil or inputTable.friction ~= nil or inputTable.elasticity ~= nil or inputTable.friction_weight ~= nil or inputTable.elasticity_weight ~= nil then -- Allow partial for custom
             local d = tonumber(inputTable.density)
             local f = tonumber(inputTable.friction)
             local e = tonumber(inputTable.elasticity)

--- a/plugin/src/Tools/AddDebrisItem.luau
+++ b/plugin/src/Tools/AddDebrisItem.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types) -- Added
-local DebrisService = game:GetService("Debris")
+local DebrisService = ToolHelpers.GetDebrisService()
 
 local function execute(args: Types.AddDebrisItemArgs) -- Type annotation added
     local success, resultOrError = pcall(function()

--- a/plugin/src/Tools/AddTag.luau
+++ b/plugin/src/Tools/AddTag.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types) -- Added
-local CollectionService = game:GetService("CollectionService")
+local CollectionService = ToolHelpers.GetCollectionService()
 
 local function execute(args: Types.AddTagArgs) -- Type annotation added
     local success, resultOrError = pcall(function()

--- a/plugin/src/Tools/ComputePath.luau
+++ b/plugin/src/Tools/ComputePath.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local PathfindingService = game:GetService("PathfindingService")
+local PathfindingService = ToolHelpers.GetPathfindingService()
 local HttpService = game:GetService("HttpService") -- Added
 
 local function execute(args: Types.ComputePathArgs)

--- a/plugin/src/Tools/CreateGuiElement.luau
+++ b/plugin/src/Tools/CreateGuiElement.luau
@@ -2,8 +2,8 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types) -- Added
-local PlayersService = game:GetService("Players")
-local StarterGuiService = game:GetService("StarterGui")
+local PlayersService = ToolHelpers.GetPlayersService()
+local StarterGuiService = ToolHelpers.GetStarterGuiService()
 local HttpService = game:GetService("HttpService") -- Added
 
 local function execute(args: Types.CreateGuiElementArgs) -- Type annotation added

--- a/plugin/src/Tools/CreateTeam.luau
+++ b/plugin/src/Tools/CreateTeam.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types) -- Added
-local TeamsService = game:GetService("Teams")
+local TeamsService = ToolHelpers.GetTeamsService()
 local HttpService = game:GetService("HttpService") -- Added
 
 local function execute(args: Types.CreateTeamArgs) -- Type annotation added

--- a/plugin/src/Tools/CreateTextChannel.luau
+++ b/plugin/src/Tools/CreateTextChannel.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types) -- Added
-local TextChatService = game:GetService("TextChatService")
+local TextChatService = ToolHelpers.GetTextChatService()
 local HttpService = game:GetService("HttpService") -- Added
 
 local function execute(args: Types.CreateTextChannelArgs) -- Type annotation added

--- a/plugin/src/Tools/FilterTextForPlayer.luau
+++ b/plugin/src/Tools/FilterTextForPlayer.luau
@@ -2,8 +2,8 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local TextService = game:GetService("TextService")
-local PlayersService = game:GetService("Players")
+local TextService = ToolHelpers.GetTextService()
+local PlayersService = ToolHelpers.GetPlayersService()
 
 local function execute(args: Types.FilterTextForPlayerArgs)
     -- Arguments are now expected directly on args table

--- a/plugin/src/Tools/GetInstancesWithTag.luau
+++ b/plugin/src/Tools/GetInstancesWithTag.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types) -- Added
-local CollectionService = game:GetService("CollectionService")
+local CollectionService = ToolHelpers.GetCollectionService()
 
 local function execute(args: Types.GetInstancesWithTagArgs) -- Type annotation added
     local success, resultOrError = pcall(function()

--- a/plugin/src/Tools/GetLightingProperty.luau
+++ b/plugin/src/Tools/GetLightingProperty.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types) -- Added
-local Lighting = game:GetService("Lighting")
+local Lighting = ToolHelpers.GetLightingService()
 
 local function execute(args: Types.GetLightingPropertyArgs) -- Type annotation added
     local success, resultOrError = pcall(function()

--- a/plugin/src/Tools/GetMouseHitCFrame.luau
+++ b/plugin/src/Tools/GetMouseHitCFrame.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local UserInputService = game:GetService("UserInputService")
+local UserInputService = ToolHelpers.GetUserInputService()
 
 local function execute(args: Types.GetMouseHitCFrameArgs)
     -- args.camera_path is optional
@@ -18,7 +18,7 @@ local function execute(args: Types.GetMouseHitCFrameArgs)
             return ToolHelpers.FormatErrorResult("UserInputService not available in this context.")
         end
 
-        local cameraToUse = workspace.CurrentCamera
+        local cameraToUse = ToolHelpers.GetWorkspaceService().CurrentCamera
         if cameraPath then
             local foundCam, err = ToolHelpers.FindInstanceByPath(cameraPath)
             if foundCam and foundCam:IsA("Camera") then
@@ -43,7 +43,7 @@ local function execute(args: Types.GetMouseHitCFrameArgs)
         --    raycastParams.FilterDescendantsInstances = {player.Character}
         -- end
 
-        local raycastResult = workspace:Raycast(unitRay.Origin, unitRay.Direction * 1000, raycastParams)
+        local raycastResult = ToolHelpers.GetWorkspaceService():Raycast(unitRay.Origin, unitRay.Direction * 1000, raycastParams)
 
         if raycastResult and raycastResult.Instance then
             local hitPosition = raycastResult.Position

--- a/plugin/src/Tools/GetMousePosition.luau
+++ b/plugin/src/Tools/GetMousePosition.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local UserInputService = game:GetService("UserInputService")
+local UserInputService = ToolHelpers.GetUserInputService()
 
 local function execute(args: Types.GetMousePositionArgs)
     -- This tool typically doesn't take arguments, but args table is passed anyway.
@@ -18,7 +18,7 @@ local function execute(args: Types.GetMousePositionArgs)
             message = "Successfully retrieved mouse 2D position.",
             x = mouseLocation.X,
             y = mouseLocation.Y,
-            viewport_size = {x = workspace.CurrentCamera and workspace.CurrentCamera.ViewportSize.X or 0, y = workspace.CurrentCamera and workspace.CurrentCamera.ViewportSize.Y or 0}
+            viewport_size = {x = ToolHelpers.GetWorkspaceService().CurrentCamera and ToolHelpers.GetWorkspaceService().CurrentCamera.ViewportSize.X or 0, y = ToolHelpers.GetWorkspaceService().CurrentCamera and ToolHelpers.GetWorkspaceService().CurrentCamera.ViewportSize.Y or 0}
         })
     end)
 

--- a/plugin/src/Tools/GetPlayersInTeam.luau
+++ b/plugin/src/Tools/GetPlayersInTeam.luau
@@ -1,7 +1,7 @@
 -- GetPlayersInTeam.luau
 local ToolHelpers = require(script.Parent.Parent.ToolHelpers)
 local Types = require(script.Parent.Parent.Types)
-local TeamsService = game:GetService("Teams")
+local TeamsService = ToolHelpers.GetTeamsService()
 
 local function execute(args: Types.GetPlayersInTeamArgs)
     local success, pcall_result = pcall(function()

--- a/plugin/src/Tools/GetProductInfo.luau
+++ b/plugin/src/Tools/GetProductInfo.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local MarketplaceService = game:GetService("MarketplaceService")
+local MarketplaceService = ToolHelpers.GetMarketplaceService()
 
 local function execute(args: Types.GetProductInfoArgs)
     local success, pcall_result = pcall(function()

--- a/plugin/src/Tools/GetTeams.luau
+++ b/plugin/src/Tools/GetTeams.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local TeamsService = game:GetService("Teams")
+local TeamsService = ToolHelpers.GetTeamsService()
 
 local function execute(args: Types.GetTeamsArgs)
     -- This tool does not currently take any specific arguments from the 'args' table.

--- a/plugin/src/Tools/GetTeleportData.luau
+++ b/plugin/src/Tools/GetTeleportData.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local PlayersService = game:GetService("Players")
+local PlayersService = ToolHelpers.GetPlayersService()
 
 local function execute(args: Types.GetTeleportDataArgs)
     -- This tool does not take arguments from the 'args' table for its core logic.

--- a/plugin/src/Tools/GetWorkspaceProperty.luau
+++ b/plugin/src/Tools/GetWorkspaceProperty.luau
@@ -13,7 +13,7 @@ local function execute(args: Types.GetWorkspacePropertyArgs) -- Type annotation 
 
         local propertyValue
         local getSuccess, valueOrError = pcall(function()
-            return workspace[propertyName]
+            return ToolHelpers.GetWorkspaceService()[propertyName]
         end)
 
         if not getSuccess then

--- a/plugin/src/Tools/IncrementData.luau
+++ b/plugin/src/Tools/IncrementData.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local DataStoreService = game:GetService("DataStoreService")
+local DataStoreService = ToolHelpers.GetDataStoreService()
 
 local function execute(args: Types.IncrementDataArgs)
     -- Arguments are expected directly on args table

--- a/plugin/src/Tools/InsertModel.luau
+++ b/plugin/src/Tools/InsertModel.luau
@@ -6,7 +6,7 @@ local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local Types = require(Main.Types)
 local ToolHelpers = require(Main.ToolHelpers)
 
-local InsertService = game:GetService("InsertService")
+local InsertService = ToolHelpers.GetInsertService()
 -- local CollectionService = game:GetService("CollectionService") -- For tagging if needed later
 
 local INSERT_MAX_SEARCH_DEPTH = 2048
@@ -15,7 +15,7 @@ local INSERT_MAX_DISTANCE_AWAY = 20
 -- Determines the 3D position in the world where the model should be inserted.
 -- It raycasts from the center of the camera's viewport.
 local function getInsertPosition(): Vector3
-	local camera = workspace.CurrentCamera
+	local camera = ToolHelpers.GetWorkspaceService().CurrentCamera
 	if not camera then return Vector3.new(0, 5, 0) end
 
 	local viewportPoint = camera.ViewportSize / 2
@@ -24,9 +24,9 @@ local function getInsertPosition(): Vector3
 	local params = RaycastParams.new()
 	params.FilterType = Enum.RaycastFilterType.Exclude
 	-- Exclude currently selected objects from the raycast target
-	params.FilterDescendantsInstances = game:GetService("Selection"):Get()
+	params.FilterDescendantsInstances = ToolHelpers.GetSelectionService():Get()
 
-	local result = workspace:Raycast(unitRay.Origin, unitRay.Direction * INSERT_MAX_SEARCH_DEPTH, params)
+	local result = ToolHelpers.GetWorkspaceService():Raycast(unitRay.Origin, unitRay.Direction * INSERT_MAX_SEARCH_DEPTH, params)
 
 	if result then
 		-- Place the model on the surface that was hit
@@ -101,7 +101,7 @@ local function performInsert(query: string, parentPath: string?): (Types.InsertM
 	-- At this point, loadedModel is guaranteed to be a non-nil Model instance.
 	loadedModel = loadedModel :: Model
 
-	local parent = workspace -- Default parent is workspace
+	local parent = ToolHelpers.GetWorkspaceService() -- Default parent is workspace
 	if parentPath then
 		local foundParent, findError = ToolHelpers.FindInstanceByPath(parentPath)
 		if not foundParent then

--- a/plugin/src/Tools/IsKeyDown.luau
+++ b/plugin/src/Tools/IsKeyDown.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local UserInputService = game:GetService("UserInputService")
+local UserInputService = ToolHelpers.GetUserInputService()
 
 local function execute(args: Types.IsKeyDownArgs)
     -- Arguments are expected directly on args table

--- a/plugin/src/Tools/IsMouseButtonDown.luau
+++ b/plugin/src/Tools/IsMouseButtonDown.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local UserInputService = game:GetService("UserInputService")
+local UserInputService = ToolHelpers.GetUserInputService()
 
 local function execute(args: Types.IsMouseButtonDownArgs)
     -- Arguments are expected directly on args table

--- a/plugin/src/Tools/KickPlayer.luau
+++ b/plugin/src/Tools/KickPlayer.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local PlayersService = game:GetService("Players")
+local PlayersService = ToolHelpers.GetPlayersService()
 
 local function find_player(pathOrName)
     -- Try finding by full name first (more specific)

--- a/plugin/src/Tools/LoadAssetById.luau
+++ b/plugin/src/Tools/LoadAssetById.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local InsertService = game:GetService("InsertService")
+local InsertService = ToolHelpers.GetInsertService()
 
 local function execute(args: Types.LoadAssetByIdArgs)
     -- Arguments are expected directly on args table
@@ -25,7 +25,7 @@ local function execute(args: Types.LoadAssetByIdArgs)
             return ToolHelpers.FormatErrorResult("InsertService not available in this context.")
         end
 
-        local parentInstance = workspace -- Default to workspace
+        local parentInstance = ToolHelpers.GetWorkspaceService() -- Default to workspace
         if parentPath then
             local foundParent, err = ToolHelpers.FindInstanceByPath(parentPath)
             if foundParent then

--- a/plugin/src/Tools/PlaySoundId.luau
+++ b/plugin/src/Tools/PlaySoundId.luau
@@ -82,7 +82,7 @@ local function execute(args: Types.PlaySoundIdArgs)
         if parentInstance then
             soundInstance.Parent = parentInstance
         else
-            soundInstance.Parent = game:GetService("SoundService")
+            soundInstance.Parent = ToolHelpers.GetSoundService()
             if not properties.PlayOnRemove then soundInstance.PlayOnRemove = true end
         end
 

--- a/plugin/src/Tools/SetWorkspaceProperty.luau
+++ b/plugin/src/Tools/SetWorkspaceProperty.luau
@@ -21,7 +21,7 @@ local function execute(args: Types.SetWorkspacePropertyArgs) -- Type annotation 
 
         if type(propertyValueInput) == "table" then
             -- Pass 'workspace' as the instance for context-aware conversion (e.g. Vector3 vs UDim2 for Size)
-            local converted_value_from_helper, err_msg_from_helper = ToolHelpers.ConvertTableToRobloxType(propertyValueInput, propertyName, workspace)
+            local converted_value_from_helper, err_msg_from_helper = ToolHelpers.ConvertTableToRobloxType(propertyValueInput, propertyName, ToolHelpers.GetWorkspaceService())
             if err_msg_from_helper then
                 conversionErrorMsg = err_msg_from_helper
             else
@@ -38,7 +38,7 @@ local function execute(args: Types.SetWorkspacePropertyArgs) -- Type annotation 
         end
 
         local setSuccess, setError = pcall(function()
-            workspace[propertyName] = finalValueToSet
+            ToolHelpers.GetWorkspaceService()[propertyName] = finalValueToSet
         end)
 
         if not setSuccess then
@@ -62,7 +62,7 @@ local function execute(args: Types.SetWorkspacePropertyArgs) -- Type annotation 
             )
         end
 
-        local actualValue = workspace[propertyName]
+        local actualValue = ToolHelpers.GetWorkspaceService()[propertyName]
         local resultData: Types.SetWorkspacePropertyResultData = {
             property_name = propertyName,
             new_value_set = actualValue,

--- a/plugin/src/Tools/TeleportPlayerToPlace.luau
+++ b/plugin/src/Tools/TeleportPlayerToPlace.luau
@@ -1,8 +1,8 @@
 -- TeleportPlayerToPlace.luau
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
-local TeleportService = game:GetService("TeleportService")
-local PlayersService = game:GetService("Players")
+local TeleportService = ToolHelpers.GetTeleportService()
+local PlayersService = ToolHelpers.GetPlayersService()
 
 local function execute(args)
     -- Arguments are expected directly on args table

--- a/plugin/src/Tools/TweenProperties.luau
+++ b/plugin/src/Tools/TweenProperties.luau
@@ -2,7 +2,7 @@
 local Main = script:FindFirstAncestor("MCPStudioPlugin")
 local ToolHelpers = require(Main.ToolHelpers)
 local Types = require(Main.Types)
-local TweenService = game:GetService("TweenService")
+local TweenService = ToolHelpers.GetTweenService()
 
 local function execute(args: Types.TweenPropertiesArgs)
     -- Arguments are expected directly on args table

--- a/plugin/src/Tools/delete_instance.luau
+++ b/plugin/src/Tools/delete_instance.luau
@@ -22,7 +22,7 @@ local function execute(args: Types.DeleteInstanceArgs) -- Type annotation added
             return resultData -- This will be handled by FormatSuccessResult
         end
 
-        if instance == workspace or instance:IsA("ServiceProvider") or instance:IsA("Terrain") then
+        if instance == ToolHelpers.GetWorkspaceService() or instance:IsA("ServiceProvider") or instance:IsA("Terrain") then
              return ("Cannot delete core services, the workspace root, or Terrain: %s"):format(path) -- Return error string
         end
 


### PR DESCRIPTION
- I modified ToolHelpers.luau to accept a service provider table via InitServices and added specific getter functions for various Roblox services.
- I updated Main.server.luau to gather and provide these services to ToolHelpers.
- I refactored all tools in plugin/src/Tools/ to use the new service getters in ToolHelpers instead of direct game:GetService() calls or direct workspace access, improving compliance with expected MCP practices.