### PR TITLE
Integrate Ollama for local LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,84 @@ To use the Gemini agent with Roblox Studio:
 
 Type your prompts into the Python agent's console. It will interact with Gemini and relay actions to Roblox Studio via the Rust MCP server.
 
+## Using Local LLMs with Ollama
+
+This project also supports using local Large Language Models (LLMs) through [Ollama](https://ollama.com/). This allows you to run powerful models directly on your own machine.
+
+**Benefits of using Ollama:**
+*   **Privacy**: Your prompts and code are processed locally, not sent to a third-party cloud service.
+*   **Offline Capability**: Once models are downloaded, you can use the agent without an active internet connection (though initial setup and model downloads require internet).
+*   **Custom Models**: Ollama supports a wide range of open-source models, and you can easily switch between them or even use customized versions.
+
+### Installation and Setup (Ollama)
+
+1.  **Prerequisites**:
+    *   Ensure your Python environment is set up as described in the "Getting Started with Gemini" section (virtual environment, `requirements.txt` installed, especially the `ollama` package).
+    *   Ollama itself needs to be installed on your system.
+
+2.  **Ollama Setup Script**:
+    This project includes a batch script to help you set up Ollama and download recommended models.
+    *   **What it does**:
+        *   Checks if Ollama is already installed.
+        *   If not installed, it provides a download link and instructions.
+        *   Pulls several common Ollama models suitable for coding tasks (e.g., `phi3:mini`, `qwen2:7b`).
+    *   **How to run it**:
+        Open a command prompt or terminal in the project root and run:
+        ```batch
+        .\ollama_setup.bat
+        ```
+        Follow the on-screen prompts.
+
+### Running the Agent with Ollama
+
+A dedicated batch script is provided to simplify running the agent with Ollama.
+
+1.  **Ensure Rust MCP Server is Running**:
+    Just like with the Gemini workflow, the Rust MCP server (`rbx-studio-mcp.exe`) must be running. Open a terminal and execute:
+    ```batch
+    run_rust_server.bat
+    ```
+    Keep this window open.
+
+2.  **Run the Ollama Agent Script**:
+    In another terminal, run the `run_ollama_agent.bat` script:
+    ```batch
+    .\run_ollama_agent.bat
+    ```
+    *   **What it does**:
+        *   Checks if Ollama is installed and if the Ollama service/daemon is running.
+        *   Attempts to start the Ollama service if it's not detected (by running a small model in the background).
+        *   Presents a menu to select which Ollama model you want to use (from the ones downloaded by `ollama_setup.bat` or a custom one).
+        *   Starts the Python agent (`main.py`) configured to use Ollama with your selected model.
+
+### Configuration Options (Ollama)
+
+The primary way to configure Ollama is through command-line arguments or the interactive menu in `run_ollama_agent.bat`. However, you can also view or (less commonly) manually edit these settings in `config.json` (created after the first run or if you manually copy `config.example.json`):
+
+*   `"LLM_PROVIDER"`: Set this to `"ollama"` to use Ollama by default (can be overridden by command-line).
+*   `"OLLAMA_API_URL"`: The API endpoint for your Ollama instance. Defaults to `"http://localhost:11434"`.
+*   `"OLLAMA_DEFAULT_MODEL"`: The default Ollama model to use if not specified by other means. Defaults to `"phi3:mini"`.
+
+### Command-Line Arguments for Ollama (`main.py`)
+
+You can also run `main.py` directly with arguments to use Ollama:
+
+*   `--llm_provider {gemini,ollama}`: Specifies the LLM provider.
+    *   Example: `python main.py --llm_provider ollama`
+*   `--ollama_model <model_name>`: Specifies which Ollama model to use. This overrides the `OLLAMA_DEFAULT_MODEL` from `config.json` and the selection from `run_ollama_agent.bat` if you run `main.py` directly.
+    *   Example: `python main.py --llm_provider ollama --ollama_model qwen2:7b`
+
+### Model Notes (Ollama)
+
+*   The `ollama_setup.bat` script attempts to download the following models:
+    *   `phi3:mini` (a capable small model)
+    *   `qwen2:7b` (a larger, powerful model)
+    *   `qwen2:7b-q4_K_M` (a quantized version of Qwen2 7B, offering a balance of performance and resource usage)
+*   You can download other models compatible with Ollama by using the command `ollama pull <another_model_name:tag>`.
+*   Once downloaded, you can use these additional models by:
+    *   Selecting the "Enter custom model name" option in `run_ollama_agent.bat`.
+    *   Using the `--ollama_model <another_model_name:tag>` command-line argument when running `main.py`.
+
 ## Known Issues
 
 ### Tool Execution Timeouts in Persistent Sessions

--- a/config_manager.py
+++ b/config_manager.py
@@ -22,7 +22,10 @@ DEFAULT_CONFIG = {
     "GEMINI_API_KEY": None, # Encouraging use of environment variable via .env
     "MCP_MAX_INITIAL_START_ATTEMPTS": 3,
     "MCP_RECONNECT_ATTEMPTS": 5,
-    "HISTORY_FILE_PATH": str(Path.home() / ".roblox_agent_history")
+    "HISTORY_FILE_PATH": str(Path.home() / ".roblox_agent_history"),
+    "OLLAMA_API_URL": "http://localhost:11434",
+    "OLLAMA_DEFAULT_MODEL": "phi3:mini",
+    "LLM_PROVIDER": "gemini" # Can be "gemini" or "ollama"
 }
 
 def load_or_create_config(r_console=None) -> dict: # Optionally pass rich console
@@ -80,7 +83,8 @@ def load_or_create_config(r_console=None) -> dict: # Optionally pass rich consol
                 json.dump(DEFAULT_CONFIG, f, indent=4)
             _print_panel(
                 f"Default configuration file '{CONFIG_FILE_NAME}' created. "
-                f"Please review it, especially for 'GEMINI_API_KEY' (use .env recommended) "
+                f"Please review it, especially for 'GEMINI_API_KEY' (if using Gemini), "
+                f"'OLLAMA_API_URL', 'OLLAMA_DEFAULT_MODEL' (if using Ollama), "
                 f"and 'RBX_MCP_SERVER_PATH'.",
                 "[green]Config Notice[/green]", style="green"
             )

--- a/console_ui.py
+++ b/console_ui.py
@@ -54,15 +54,65 @@ class ConsoleFormatter:
             error_json = Text(str(error))
         console.print(Panel(error_json, title="[bold red]❌ Tool Error[/bold red]", border_style="red"))
 
+    # --- Generic Provider Methods ---
+    @staticmethod
+    def print_provider_response_header(provider_name: str):
+        style = "purple" # Default for Gemini
+        if provider_name.lower() == "ollama":
+            style = "orange1" # Rich color name for orange
+        elif provider_name.lower() == "gemini":
+            style = "purple"
+        console.print(Text(f"{provider_name.capitalize()}:", style=f"bold {style}"), end=" ")
+
+    @staticmethod
+    def print_provider_response_chunk(provider_name: str, text: str):
+        style = "purple"
+        if provider_name.lower() == "ollama":
+            style = "orange1"
+        elif provider_name.lower() == "gemini":
+            style = "purple"
+        console.print(Text(text, style=style), end="")
+
+    @staticmethod
+    def print_provider_message(provider_name: str, text: str):
+        style = "purple"
+        title_style = "bold purple"
+        if provider_name.lower() == "ollama":
+            style = "orange1"
+            title_style = "bold orange1"
+        elif provider_name.lower() == "gemini":
+            style = "purple"
+            title_style = "bold purple"
+        console.print(Panel(Text(text, style=style), title=f"[{title_style}]{provider_name.capitalize()}[/{title_style}]", border_style=style))
+
+    @staticmethod
+    def print_provider_error(provider_name: str, text: str):
+        style = "red" # Errors are typically red
+        title_style = "bold red"
+        # It's an error, so panel is red. Provider name is in the title.
+        console.print(Panel(Text(text, style=style), title=f"[{title_style}]{provider_name.capitalize()} Error[/{title_style}]", border_style=style))
+
+
 # Example usage (for testing this module directly)
 if __name__ == '__main__':
     from typing import Any # Required for example usage
     ConsoleFormatter.print_user("This is a test user message.")
-    ConsoleFormatter.print_gemini("This is a test Gemini message.")
-    ConsoleFormatter.print_gemini_header()
-    ConsoleFormatter.print_gemini_chunk("This is a ")
-    ConsoleFormatter.print_gemini_chunk("streamed Gemini message.")
+    ConsoleFormatter.print_gemini("This is a test Gemini message.") # Legacy
+    ConsoleFormatter.print_provider_message("Gemini", "This is a test Gemini message via generic method.")
+    ConsoleFormatter.print_provider_response_header("Gemini")
+    ConsoleFormatter.print_provider_response_chunk("Gemini", "This is a ")
+    ConsoleFormatter.print_provider_response_chunk("Gemini", "streamed Gemini message.")
     console.print() # for newline
+
+    ConsoleFormatter.print_provider_message("Ollama", "This is a test Ollama message via generic method.")
+    ConsoleFormatter.print_provider_response_header("Ollama")
+    ConsoleFormatter.print_provider_response_chunk("Ollama", "This is a ")
+    ConsoleFormatter.print_provider_response_chunk("Ollama", "streamed Ollama message.")
+    console.print() # for newline
+
+    ConsoleFormatter.print_provider_error("Gemini", "This is a Gemini error.")
+    ConsoleFormatter.print_provider_error("Ollama", "This is an Ollama error.")
+
     ConsoleFormatter.print_tool_call("test_tool", {"param1": "value1", "param2": 123})
     ConsoleFormatter.print_tool_result({"status": "success", "data": [1, 2, 3]})
     ConsoleFormatter.print_tool_error({"error_code": 500, "message": "Something went wrong."})

--- a/main.py
+++ b/main.py
@@ -29,8 +29,7 @@ from config_manager import config, DEFAULT_CONFIG, ROOT_DIR
 from console_ui import ConsoleFormatter, console
 from mcp_client import MCPClient, MCPConnectionError
 # III.1. Import ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE
-from gemini_tools import ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE, ToolDispatcher
-
+from gemini_tools import ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE, ToolDispatcher, FunctionCall, get_ollama_tools_json_schema # Added FunctionCall and get_ollama_tools_json_schema
 
 # --- Script Configuration & Constants using loaded config ---
 load_dotenv()
@@ -38,23 +37,55 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__) # Logger for this main application file
 
-ENV_GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
-CONFIG_GEMINI_API_KEY = config.get("GEMINI_API_KEY")
+# --- Argument Parsing ---
+parser = argparse.ArgumentParser(description="Roblox Studio AI Broker")
+parser.add_argument(
+    "--llm_provider",
+    type=str,
+    choices=["gemini", "ollama"],
+    default=config.get("LLM_PROVIDER", DEFAULT_CONFIG["LLM_PROVIDER"]),
+    help="The LLM provider to use (gemini or ollama)."
+)
+parser.add_argument(
+    "--ollama_model",
+    type=str,
+    default=config.get("OLLAMA_DEFAULT_MODEL", DEFAULT_CONFIG["OLLAMA_DEFAULT_MODEL"]),
+    help="The Ollama model to use (if --llm_provider is ollama)."
+)
+parser.add_argument("--test_command", type=str, help="Execute a single test command and exit.")
+parser.add_argument('--test_file', type=str, help='Path to a file containing a list of test commands, one per line.')
+args = parser.parse_args()
 
-if ENV_GEMINI_API_KEY:
-    GEMINI_API_KEY = ENV_GEMINI_API_KEY
-    logger.info("Using GEMINI_API_KEY from environment variable.")
-elif CONFIG_GEMINI_API_KEY and CONFIG_GEMINI_API_KEY != "None" and CONFIG_GEMINI_API_KEY is not None:
-    GEMINI_API_KEY = CONFIG_GEMINI_API_KEY
-    logger.info("Using GEMINI_API_KEY from config.json.")
+# --- LLM Configuration ---
+LLM_PROVIDER = args.llm_provider
+OLLAMA_API_URL = config.get("OLLAMA_API_URL", DEFAULT_CONFIG["OLLAMA_API_URL"])
+OLLAMA_MODEL_NAME = args.ollama_model # This now comes from args, falling back to config via argparse default
+
+if LLM_PROVIDER == "gemini":
+    ENV_GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
+    CONFIG_GEMINI_API_KEY = config.get("GEMINI_API_KEY")
+
+    if ENV_GEMINI_API_KEY:
+        GEMINI_API_KEY = ENV_GEMINI_API_KEY
+        logger.info("Using GEMINI_API_KEY from environment variable.")
+    elif CONFIG_GEMINI_API_KEY and CONFIG_GEMINI_API_KEY != "None" and CONFIG_GEMINI_API_KEY is not None:
+        GEMINI_API_KEY = CONFIG_GEMINI_API_KEY
+        logger.info("Using GEMINI_API_KEY from config.json.")
+    else:
+        console.print(Panel("[bold yellow]Warning:[/bold yellow] GEMINI_API_KEY not found for Gemini provider. Using a dummy key 'DUMMY_KEY'. Gemini calls will likely fail.", title="[yellow]Config Warning[/yellow]"))
+        GEMINI_API_KEY = "DUMMY_KEY" # Provide a dummy key
+
+    GEMINI_MODEL_NAME = os.environ.get("GEMINI_MODEL_NAME") or \
+                        config.get("GEMINI_MODEL_NAME") or \
+                        DEFAULT_CONFIG["GEMINI_MODEL_NAME"]
+    logger.info(f"Using Gemini Model: {GEMINI_MODEL_NAME}")
+elif LLM_PROVIDER == "ollama":
+    logger.info(f"Using Ollama provider with API URL: {OLLAMA_API_URL} and Model: {OLLAMA_MODEL_NAME}")
+    # Ollama client will be initialized in main_loop
 else:
-    console.print(Panel("[bold yellow]Warning:[/bold yellow] GEMINI_API_KEY not found. Using a dummy key 'DUMMY_KEY' for testing tool dispatch. Gemini calls will likely fail.", title="[yellow]Config Warning[/yellow]"))
-    GEMINI_API_KEY = "DUMMY_KEY" # Provide a dummy key to proceed
+    logger.error(f"Invalid LLM_PROVIDER: {LLM_PROVIDER}. Exiting.")
+    sys.exit(1)
 
-GEMINI_MODEL_NAME = os.environ.get("GEMINI_MODEL_NAME") or \
-                    config.get("GEMINI_MODEL_NAME") or \
-                    DEFAULT_CONFIG["GEMINI_MODEL_NAME"]
-logger.info(f"Using Gemini Model: {GEMINI_MODEL_NAME}")
 
 RBX_MCP_SERVER_PATH_STR = config.get("RBX_MCP_SERVER_PATH", DEFAULT_CONFIG["RBX_MCP_SERVER_PATH"])
 _rbx_mcp_path = Path(RBX_MCP_SERVER_PATH_STR)
@@ -78,9 +109,20 @@ except Exception as e:
 session = PromptSession(history=FileHistory(str(history_file)))
 
 
-async def _process_command(user_input_str: str, chat_session, tool_dispatcher, console, logger, is_test_file_command: bool = False) -> bool:
+async def _process_command(
+    user_input_str: str,
+    llm_provider: str,
+    chat_session, # Can be Gemini chat session or Ollama client
+    tool_dispatcher,
+    console,
+    logger,
+    ollama_model_name: str = None, # Only for Ollama
+    ollama_history: list = None, # Only for Ollama, stores message history
+    gemini_model_resource_name: str = None, # Only for Gemini
+    is_test_file_command: bool = False
+) -> bool:
     """
-    Processes a single command through the Gemini chat session, including tool calls and retries.
+    Processes a single command through the selected LLM provider, including tool calls and retries.
     Returns True if the command processing completed (even with handled errors),
     False if a critical/unrecoverable error occurred (e.g., max API retries).
     """
@@ -95,80 +137,133 @@ async def _process_command(user_input_str: str, chat_session, tool_dispatcher, c
         while current_retry_attempt < MAX_API_RETRIES:
             try:
                 if current_retry_attempt > 0:
-                    with console.status(f"[bold yellow]Gemini API error. Retrying in {current_delay:.1f}s (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES})...[/bold yellow]", spinner="dots") as status_spinner_gemini_retry:
-                        await asyncio.sleep(current_delay)
-                with console.status(f"[bold green]Gemini is thinking... (Attempt {current_retry_attempt + 1})[/bold green]", spinner="dots") as status_spinner_gemini:
-                    response = await chat_session.send_message(
-                        message=user_input_str,
-                        config=types.GenerateContentConfig(tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE])
-                    )
-                break # Success
-            except ServerError as e:
-                logger.warning(f"Gemini API ServerError (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES}): {e}")
-                current_retry_attempt += 1
-                if current_retry_attempt >= MAX_API_RETRIES:
-                    logger.error(f"Max retries reached for Gemini API call. Last error: {e}")
-                    ConsoleFormatter.print_gemini(f"I encountered a persistent server error after {MAX_API_RETRIES} attempts: {e.message or str(e)}")
+                if llm_provider == "gemini":
+                    if current_retry_attempt > 0:
+                        with console.status(f"[bold yellow]Gemini API error. Retrying in {current_delay:.1f}s (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES})...[/bold yellow]", spinner="dots") as status_spinner_gemini_retry:
+                            await asyncio.sleep(current_delay)
+                    with console.status(f"[bold green]Gemini is thinking... (Attempt {current_retry_attempt + 1})[/bold green]", spinner="dots") as status_spinner_gemini:
+                        response = await chat_session.send_message( # chat_session is the Gemini chat
+                            message=user_input_str,
+                            config=types.GenerateContentConfig(tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE])
+                        )
+                    break # Success
+                elif llm_provider == "ollama":
+                    # Ollama doesn't have explicit retries in the same way, but we can implement a similar loop
+                    if current_retry_attempt > 0:
+                        with console.status(f"[bold yellow]Ollama API error. Retrying in {current_delay:.1f}s (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES})...[/bold yellow]", spinner="dots") as status_spinner_ollama_retry:
+                            await asyncio.sleep(current_delay)
+                    with console.status(f"[bold green]Ollama is thinking... (Attempt {current_retry_attempt + 1})[/bold green]", spinner="dots") as status_spinner_ollama:
+                        # Add user message to history
+                        ollama_history.append({'role': 'user', 'content': user_input_str})
+
+                        # Get tools in Ollama format
+                        ollama_formatted_tools = get_ollama_tools_json_schema()
+
+                        response = await asyncio.to_thread(
+                            chat_session.chat, # chat_session is the Ollama client
+                            model=ollama_model_name,
+                            messages=ollama_history,
+                            tools=ollama_formatted_tools if ollama_formatted_tools else None # Pass tools to Ollama
+                        )
+                    # Add assistant response to history (even if it's a tool call)
+                    if response and response.get('message'):
+                        ollama_history.append(response['message'])
+                    break # Success for Ollama
+
+            except ServerError as e: # Gemini specific
+                if llm_provider == "gemini":
+                    logger.warning(f"Gemini API ServerError (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES}): {e}")
+                    current_retry_attempt += 1
+                    if current_retry_attempt >= MAX_API_RETRIES:
+                        logger.error(f"Max retries reached for Gemini API call. Last error: {e}")
+                        ConsoleFormatter.print_provider_error("Gemini", f"I encountered a persistent server error after {MAX_API_RETRIES} attempts: {e.message or str(e)}")
+                        command_processed_successfully = False
+                        break
+                    current_delay *= RETRY_BACKOFF_FACTOR
+                else: # Should not happen for Ollama here
+                    logger.error(f"Unexpected ServerError with {llm_provider}: {e}", exc_info=True)
+                    ConsoleFormatter.print_provider_error(llm_provider, f"An unexpected server error occurred: {str(e)}")
                     command_processed_successfully = False
                     break
-                current_delay *= RETRY_BACKOFF_FACTOR
             except asyncio.TimeoutError as e:
-                logger.warning(f"Gemini API TimeoutError (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES}): {e}")
+                logger.warning(f"{llm_provider.capitalize()} API TimeoutError (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES}): {e}")
                 current_retry_attempt += 1
                 if current_retry_attempt >= MAX_API_RETRIES:
-                    logger.error(f"Max retries reached for Gemini API call due to timeout. Last error: {e}")
-                    ConsoleFormatter.print_gemini(f"The request to Gemini timed out after {MAX_API_RETRIES} attempts.")
+                    logger.error(f"Max retries reached for {llm_provider.capitalize()} API call due to timeout. Last error: {e}")
+                    ConsoleFormatter.print_provider_error(llm_provider, f"The request timed out after {MAX_API_RETRIES} attempts.")
                     command_processed_successfully = False
                     break
                 current_delay *= RETRY_BACKOFF_FACTOR
-            except Exception as e:
-                logger.error(f"Unexpected error during Gemini API call (Attempt {current_retry_attempt + 1}): {e}", exc_info=True)
-                ConsoleFormatter.print_gemini(f"I encountered an unexpected error while trying to reach Gemini: {str(e)}")
+            except Exception as e: # General errors (e.g., ollama connection error)
+                logger.error(f"Unexpected error during {llm_provider.capitalize()} API call (Attempt {current_retry_attempt + 1}): {e}", exc_info=True)
+                error_message = str(e)
+                if llm_provider == "ollama" and "Connection refused" in error_message:
+                     ConsoleFormatter.print_provider_error(llm_provider, f"Could not connect to Ollama at {OLLAMA_API_URL}. Ensure Ollama is running.")
+                else:
+                    ConsoleFormatter.print_provider_error(llm_provider, f"I encountered an unexpected error: {error_message}")
                 command_processed_successfully = False
-                break
+                break # Break from retry loop
 
         if response is None: # Failed to get initial response
-            if is_test_file_command: # Only print this specific message if it's part of a test file sequence
-                 console.print(f"[bold red]Skipping processing for command '{user_input_str}' due to API failure.[/bold red]")
+            if is_test_file_command:
+                 console.print(f"[bold red]Skipping processing for command '{user_input_str}' due to API failure with {llm_provider}.[/bold red]")
             return False # Indicate critical failure
 
         # Inner loop for handling a sequence of function calls
-        while True:
+        while True: # Loop for iterative tool calls
             pending_function_calls = []
-            if response.candidates and response.candidates[0].content and response.candidates[0].content.parts:
-                for part in response.candidates[0].content.parts:
-                    if hasattr(part, 'function_call') and part.function_call and part.function_call.name:
-                        pending_function_calls.append(part.function_call)
+            if llm_provider == "gemini":
+                if response.candidates and response.candidates[0].content and response.candidates[0].content.parts:
+                    for part in response.candidates[0].content.parts:
+                        if hasattr(part, 'function_call') and part.function_call and part.function_call.name:
+                            pending_function_calls.append(part.function_call)
+            elif llm_provider == "ollama":
+                if response and response.get('message') and response['message'].get('tool_calls'):
+                    for ollama_tc in response['message']['tool_calls']:
+                        # Adapt Ollama tool call to Gemini's FunctionCall like structure for ToolDispatcher
+                        # This assumes Ollama's tool call has 'name' and 'arguments' (or similar)
+                        # Example: ollama_tc might be {'function': {'name': 'tool_name', 'arguments': {...}}}
+                        if ollama_tc.get('function') and ollama_tc['function'].get('name'):
+                            fc_name = ollama_tc['function']['name']
+                            fc_args = ollama_tc['function'].get('arguments', {})
+                            pending_function_calls.append(FunctionCall(name=fc_name, args=fc_args))
+                        else:
+                            logger.warning(f"Ollama tool call in unexpected format: {ollama_tc}")
+
 
             if not pending_function_calls:
-                break # No more function calls from the model, exit inner loop
+                break # No more function calls from the model, exit inner tool processing loop
 
             tool_tasks = []
             for fc_to_execute in pending_function_calls:
+                # ToolDispatcher expects FunctionCall objects (or dicts that look like them)
                 tool_tasks.append(tool_dispatcher.execute_tool_call(fc_to_execute))
 
-            tool_call_results = await asyncio.gather(*tool_tasks)
+            tool_call_results = await asyncio.gather(*tool_tasks) # Results are dicts: {'name': ..., 'response': ...}
 
-            tool_response_parts = []
-            for result_dict in tool_call_results:
-                tool_response_parts.append(
-                    types.Part(function_response=types.FunctionResponse(
-                        name=result_dict['name'],
-                        response=result_dict['response']
-                    ))
-                )
+            if llm_provider == "gemini":
+                tool_response_parts = []
+                for result_dict in tool_call_results:
+                    tool_response_parts.append(
+                        types.Part(function_response=types.FunctionResponse(
+                            name=result_dict['name'],
+                            response=result_dict['response']
+                        ))
+                    )
+                if not tool_response_parts:
+                    logger.warning("No tool response parts to send for Gemini, though function calls were expected.")
+                    break # Should not happen if pending_function_calls was not empty
 
-            if tool_response_parts:
+                # Send tool results back to Gemini
                 current_retry_attempt_tool = 0
                 current_delay_tool = INITIAL_RETRY_DELAY_SECONDS
                 response_tool_call = None
-
                 while current_retry_attempt_tool < MAX_API_RETRIES:
                     try:
                         if current_retry_attempt_tool > 0:
-                            with console.status(f"[bold yellow]Gemini API error (tool response). Retrying in {current_delay_tool:.1f}s (Attempt {current_retry_attempt_tool + 1}/{MAX_API_RETRIES})...[/bold yellow]", spinner="dots") as status_spinner_gemini_retry_tool:
+                            with console.status(f"[bold yellow]Gemini API error (tool response). Retrying in {current_delay_tool:.1f}s...[/bold yellow]", spinner="dots"):
                                 await asyncio.sleep(current_delay_tool)
-                        with console.status(f"[bold green]Gemini is processing tool results... (Attempt {current_retry_attempt_tool + 1})[/bold green]", spinner="dots") as status_spinner_gemini_processing:
+                        with console.status(f"[bold green]Gemini is processing tool results...[/bold green]", spinner="dots"):
                             response_tool_call = await chat_session.send_message(
                                 message=tool_response_parts,
                                 config=types.GenerateContentConfig(tools=[ROBLOX_MCP_TOOLS_NEW_SDK_INSTANCE])
@@ -176,176 +271,289 @@ async def _process_command(user_input_str: str, chat_session, tool_dispatcher, c
                         break # Success
                     except ServerError as e:
                         logger.warning(f"Gemini API ServerError (tool response) (Attempt {current_retry_attempt_tool + 1}/{MAX_API_RETRIES}): {e}")
+                        # ... (rest of Gemini retry logic for tool response)
                         current_retry_attempt_tool += 1
                         if current_retry_attempt_tool >= MAX_API_RETRIES:
-                            logger.error(f"Max retries reached for Gemini API call (tool response). Last error: {e}")
-                            ConsoleFormatter.print_gemini(f"I encountered a persistent server error sending tool results after {MAX_API_RETRIES} attempts: {e.message or str(e)}")
-                            command_processed_successfully = False
-                            break
+                            ConsoleFormatter.print_provider_error("Gemini", f"Max retries sending tool results: {e.message or str(e)}")
+                            command_processed_successfully = False; break
                         current_delay_tool *= RETRY_BACKOFF_FACTOR
                     except asyncio.TimeoutError as e:
                         logger.warning(f"Gemini API TimeoutError (tool response) (Attempt {current_retry_attempt_tool + 1}/{MAX_API_RETRIES}): {e}")
                         current_retry_attempt_tool += 1
                         if current_retry_attempt_tool >= MAX_API_RETRIES:
-                            logger.error(f"Max retries reached for Gemini API call (tool response) due to timeout. Last error: {e}")
-                            ConsoleFormatter.print_gemini(f"The request to Gemini for tool results timed out after {MAX_API_RETRIES} attempts.")
-                            command_processed_successfully = False
-                            break
+                            ConsoleFormatter.print_provider_error("Gemini", f"Timeout sending tool results after {MAX_API_RETRIES} attempts.")
+                            command_processed_successfully = False; break
                         current_delay_tool *= RETRY_BACKOFF_FACTOR
                     except Exception as e:
-                        logger.error(f"Unexpected error during Gemini API call (tool response) (Attempt {current_retry_attempt_tool + 1}): {e}", exc_info=True)
-                        ConsoleFormatter.print_gemini(f"I encountered an unexpected error sending tool results to Gemini: {str(e)}")
-                        command_processed_successfully = False
-                        break
+                        logger.error(f"Unexpected error Gemini API (tool response) (Attempt {current_retry_attempt_tool + 1}): {e}", exc_info=True)
+                        ConsoleFormatter.print_provider_error("Gemini", f"Unexpected error sending tool results: {str(e)}")
+                        command_processed_successfully = False; break
+                response = response_tool_call # Update main response with Gemini's reply after tool call
 
-                response = response_tool_call
-                if response is None: # Failed to get response after tool call
-                    logger.warning("Failed to send/receive tool responses to/from Gemini after multiple retries. Breaking from tool processing loop.")
-                    return False # Indicate critical failure
+            elif llm_provider == "ollama":
+                # Send tool results back to Ollama
+                # Ollama expects tool results in a specific format in the messages list
+                for result_dict in tool_call_results:
+                    # Find the original tool call ID if Ollama provides one and requires it for the response.
+                    # This part is highly dependent on how Ollama handles tool call IDs.
+                    # For now, assuming a simple list of tool results.
+                    # The 'response' from tool_dispatcher is already a dict, convert to string if needed by Ollama.
+                    ollama_history.append({
+                        'role': 'tool',
+                        'content': json.dumps(result_dict['response']), # Ensure content is serializable (e.g. JSON string)
+                        'name': result_dict['name'] # Or however Ollama expects to map results to calls
+                    })
+
+                current_retry_attempt_tool = 0
+                current_delay_tool = INITIAL_RETRY_DELAY_SECONDS
+                response_tool_call = None
+                while current_retry_attempt_tool < MAX_API_RETRIES: # Retry loop for Ollama after tool call
+                    try:
+                        if current_retry_attempt_tool > 0:
+                            with console.status(f"[bold yellow]Ollama API error (tool response). Retrying in {current_delay_tool:.1f}s...[/bold yellow]", spinner="dots"):
+                                await asyncio.sleep(current_delay_tool)
+                        with console.status(f"[bold green]Ollama is processing tool results...[/bold green]", spinner="dots"):
+                            response_tool_call = await asyncio.to_thread(
+                                chat_session.chat, # Ollama client
+                                model=ollama_model_name,
+                            messages=ollama_history,
+                            tools=get_ollama_tools_json_schema() if get_ollama_tools_json_schema() else None # Resend tools if needed by Ollama
+                            )
+                        if response_tool_call and response_tool_call.get('message'):
+                             ollama_history.append(response_tool_call['message']) # Add Ollama's new response to history
+                        break # Success
+                    except asyncio.TimeoutError as e: # Specific Ollama timeout for tool response
+                        logger.warning(f"Ollama API TimeoutError (tool response) (Attempt {current_retry_attempt_tool + 1}/{MAX_API_RETRIES}): {e}")
+                        current_retry_attempt_tool += 1
+                        if current_retry_attempt_tool >= MAX_API_RETRIES:
+                             ConsoleFormatter.print_provider_error("Ollama", f"Timeout sending tool results after {MAX_API_RETRIES} attempts.")
+                             command_processed_successfully = False; break
+                        current_delay_tool *= RETRY_BACKOFF_FACTOR
+                    except Exception as e: # Covers connection errors, etc.
+                        logger.error(f"Ollama API error (tool response) (Attempt {current_retry_attempt_tool + 1}): {e}", exc_info=True)
+                        ConsoleFormatter.print_provider_error("Ollama", f"API error sending tool results: {str(e)}")
+                        current_retry_attempt_tool += 1
+                        if current_retry_attempt_tool >= MAX_API_RETRIES:
+                            command_processed_successfully = False; break
+                        current_delay_tool *= RETRY_BACKOFF_FACTOR
+                response = response_tool_call # Update main response with Ollama's reply
+
+            if not command_processed_successfully or response is None:
+                logger.warning(f"Failed to get valid response from {llm_provider} after tool processing. Breaking from tool loop.")
+                return False # Indicate critical failure for the command
+
+        # Print final response from LLM
+        if llm_provider == "gemini":
+            if response and response.text:
+                ConsoleFormatter.print_provider_response_header("Gemini")
+                for char_chunk in response.text:
+                    ConsoleFormatter.print_provider_response_chunk("Gemini", char_chunk)
+                console.print()
+            elif response and response.candidates and response.candidates[0].content and response.candidates[0].content.parts:
+                text_content = "".join(part.text for part in response.candidates[0].content.parts if hasattr(part, 'text') and part.text)
+                if text_content:
+                    ConsoleFormatter.print_provider_response_header("Gemini")
+                    for char_chunk in text_content:
+                        ConsoleFormatter.print_provider_response_chunk("Gemini", char_chunk)
+                    console.print()
+                else:
+                    ConsoleFormatter.print_provider_message("Gemini", "(No text content found in final response parts)")
             else:
-                logger.warning("No tool response parts to send, though function calls were expected.")
-                break # Should not happen if pending_function_calls was not empty
-
-        # Print final response from Gemini
-        if response and response.text:
-            ConsoleFormatter.print_gemini_header()
-            for char_chunk in response.text:
-                 ConsoleFormatter.print_gemini_chunk(char_chunk)
-            console.print()
-        elif response and response.candidates and response.candidates[0].content and response.candidates[0].content.parts:
-            text_content = "".join(part.text for part in response.candidates[0].content.parts if hasattr(part, 'text') and part.text)
-            if text_content:
-                ConsoleFormatter.print_gemini_header()
-                for char_chunk in text_content:
-                    ConsoleFormatter.print_gemini_chunk(char_chunk)
+                ConsoleFormatter.print_provider_message("Gemini", "(No text response or recognizable content from Gemini)")
+        elif llm_provider == "ollama":
+            if response and response.get('message') and response['message'].get('content'):
+                ConsoleFormatter.print_provider_response_header("Ollama")
+                # Ollama response is typically not streamed char by char here unless we implement that
+                ConsoleFormatter.print_provider_response_chunk("Ollama", response['message']['content'])
                 console.print()
             else:
-                ConsoleFormatter.print_gemini("(No text content found in final response parts)")
-        else:
-            ConsoleFormatter.print_gemini("(No text response or recognizable content)")
+                ConsoleFormatter.print_provider_message("Ollama", "(No text content in final response from Ollama)")
 
     except MCPConnectionError as e:
-        logger.warning(f"MCP Connection Error while processing command '{user_input_str}': {e}")
+        logger.warning(f"MCP Connection Error while processing command '{user_input_str}' with {llm_provider}: {e}")
         console.print(Panel(f"[yellow]Connection issue: {e}. Check MCP server and Roblox Studio.[/yellow]", title="[yellow]MCP Warning[/yellow]"))
-        if is_test_file_command: # For test files, this is a command failure
+        if is_test_file_command:
             command_processed_successfully = False
-        # For interactive mode, the main loop's reconnect logic will handle this.
-        # For single --test_command, this will also be a failure.
-    except asyncio.TimeoutError:
-        logger.error(f"A request to Gemini or a tool timed out for command: {user_input_str}.")
-        console.print(Panel("[bold red]A request timed out. Please try again.[/bold red]", title="[red]Timeout Error[/red]"))
+    except asyncio.TimeoutError: # General timeout for the whole command processing
+        logger.error(f"A request to {llm_provider} or a tool timed out for command: {user_input_str}.")
+        console.print(Panel(f"[bold red]A request to {llm_provider} or a tool timed out. Please try again.[/bold red]", title="[red]Timeout Error[/red]"))
         command_processed_successfully = False
     except Exception as e:
-        logger.error(f"An error occurred during the chat loop for command '{user_input_str}': {e}", exc_info=True)
-        if hasattr(e, 'message') and isinstance(e.message, str):
-            ConsoleFormatter.print_gemini(f"I encountered an internal error: {e.message}")
-        else:
-            ConsoleFormatter.print_gemini(f"I encountered an internal error: {str(e)}")
+        logger.error(f"An error occurred during the chat loop for command '{user_input_str}' with {llm_provider}: {e}", exc_info=True)
+        error_msg = getattr(e, 'message', str(e))
+        ConsoleFormatter.print_provider_error(llm_provider, f"I encountered an internal error: {error_msg}")
         command_processed_successfully = False
 
     return command_processed_successfully
 
 
 async def main_loop():
-    """Main entry point for the Roblox Studio Gemini Broker."""
-    # Set the transport to 'async' for asyncio compatibility
-    client = genai.Client(api_key=GEMINI_API_KEY)
-    model_resource_name = f"models/{GEMINI_MODEL_NAME}"
+    """Main entry point for the Roblox Studio AI Broker."""
 
-    # III.2. Replace GenerativeModel and start_chat
-    system_instruction_text = (
-        "You are an expert AI assistant for Roblox Studio, named Gemini-Roblox-Broker. "
-        "Your goal is to help users by using the provided tools to interact with their game development environment. "
-        "First, think step-by-step about the user's request. "
-        "Then, call the necessary tools with correctly formatted arguments. "
-        "If a request is ambiguous, ask clarifying questions. "
-        "After a tool is used, summarize the result for the user. "
-        "You cannot see the screen or the project explorer, so rely on the tool outputs for information."
-    )
-    # Create chat session using client.aio.chats.create
+    llm_client = None # Will be Gemini client or Ollama client
+    chat_session = None # Gemini's chat session or Ollama's message history list
+    gemini_model_resource_name = None # Specific to Gemini
 
-    chat_session = client.aio.chats.create( # III.2. Rename chat to chat_session
+    if LLM_PROVIDER == "gemini":
+        try:
+            client = genai.Client(api_key=GEMINI_API_KEY) # transport='async' is default for genai.Client
+            gemini_model_resource_name = f"models/{GEMINI_MODEL_NAME}"
+            llm_client = client # For Gemini, llm_client is the genai.Client itself
+            system_instruction_text = (
+                "You are an expert AI assistant for Roblox Studio, named Gemini-Roblox-Broker. "
+                "Your goal is to help users by using the provided tools to interact with their game development environment. "
+                "First, think step-by-step about the user's request. "
+                "Then, call the necessary tools with correctly formatted arguments. "
+                "If a request is ambiguous, ask clarifying questions. "
+                "After a tool is used, summarize the result for the user. "
+                "You cannot see the screen or the project explorer, so rely on the tool outputs for information."
+            )
+            chat_session = llm_client.aio.chats.create( # Gemini chat session
+                model=gemini_model_resource_name,
+                history=[
+                    types.Content(role="user", parts=[types.Part(text=system_instruction_text)]),
+                    types.Content(role="model", parts=[types.Part(text="Understood. I will act as an expert AI assistant for Roblox Studio.")])
+                ]
+            )
+            logger.info(f"Gemini client and chat session initialized for model {GEMINI_MODEL_NAME}.")
+        except Exception as e:
+            logger.critical(f"Failed to initialize Gemini client: {e}", exc_info=True)
+            console.print(Panel(f"[bold red]Critical Error:[/bold red] Failed to initialize Gemini: {e}", title="[red]LLM Init Error[/red]"))
+            return
+    elif LLM_PROVIDER == "ollama":
+        try:
+            import ollama # Dynamic import
+            # Note: ollama.AsyncClient could be used if available and preferred for async operations
+            llm_client = ollama.Client(host=OLLAMA_API_URL)
+            # Test connection to Ollama by listing local models or a similar lightweight call
+            try:
+                await asyncio.to_thread(llm_client.list) # Test call
+                logger.info(f"Successfully connected to Ollama at {OLLAMA_API_URL}")
+            except Exception as e: # Catch connection errors specifically if possible
+                logger.error(f"Failed to connect to Ollama at {OLLAMA_API_URL}: {e}")
+                console.print(Panel(f"[bold red]Warning:[/bold red] Could not connect to Ollama server at '{OLLAMA_API_URL}'. "
+                                    f"Please ensure Ollama is running and accessible. Error: {e}", title="[yellow]Ollama Connection Error[/yellow]"))
+                # Decide if you want to exit or proceed with a non-functional Ollama client
+                # For now, let's proceed, _process_command will handle failures.
 
-        model=model_resource_name,
-        history=[
-            types.Content(role="user", parts=[types.Part(text=system_instruction_text)]),
-            types.Content(role="model", parts=[types.Part(text="Understood. I will act as an expert AI assistant for Roblox Studio.")])
-        ]
-    )
+            # Ollama uses a list of messages for history.
+            # The system prompt for Ollama might need different formatting or content.
+            # For now, using a similar system prompt.
+            ollama_system_prompt = (
+                "You are an expert AI assistant for Roblox Studio. "
+                "Your goal is to help users by using the provided tools to interact with their game development environment. "
+                "Think step-by-step. Call tools with correct arguments. Ask clarifying questions if needed. Summarize tool results."
+            )
+            chat_session = [{'role': 'system', 'content': ollama_system_prompt}] # This is the history for Ollama
+            logger.info(f"Ollama client initialized. Target model: {OLLAMA_MODEL_NAME}. System prompt set.")
+        except ImportError:
+            logger.critical("Ollama provider selected, but 'ollama' library is not installed. Please run: pip install ollama")
+            console.print(Panel("[bold red]Critical Error:[/bold red] Ollama library not found. Please install it with `pip install ollama`.", title="[red]Dependency Error[/red]"))
+            return
+        except Exception as e:
+            logger.critical(f"Failed to initialize Ollama client: {e}", exc_info=True)
+            console.print(Panel(f"[bold red]Critical Error:[/bold red] Failed to initialize Ollama: {e}", title="[red]LLM Init Error[/red]"))
+            return
+
 
     mcp_client = MCPClient(
         RBX_MCP_SERVER_PATH,
         max_initial_start_attempts=MCP_MAX_INITIAL_START_ATTEMPTS,
         reconnect_attempts=MCP_RECONNECT_ATTEMPTS
     )
+    # ToolDispatcher needs to be compatible with both Gemini's FunctionCall and adapted Ollama tool calls
     tool_dispatcher = ToolDispatcher(mcp_client)
-    mcp_client_instance = None # To store the mcp_client for finally block
+    mcp_client_instance = None
 
     try:
-        mcp_client_instance = mcp_client # Assign for finally block
-        from rich.status import Status # Import here
+        mcp_client_instance = mcp_client
+        from rich.status import Status # Import here if not already global
         with console.status("[bold green]Starting MCP Server...", spinner="dots") as status_spinner_mcp:
             await mcp_client.start()
 
-        console.print(Panel("[bold green]Roblox Studio Gemini Broker Initialized[/bold green]",
+        active_model_display = ""
+        if LLM_PROVIDER == "gemini":
+            active_model_display = f"Gemini Model: {GEMINI_MODEL_NAME}"
+        elif LLM_PROVIDER == "ollama":
+            active_model_display = f"Ollama Model: {OLLAMA_MODEL_NAME} (via {OLLAMA_API_URL})"
+
+        console.print(Panel(f"[bold green]Roblox Studio AI Broker Initialized ({LLM_PROVIDER.capitalize()})[/bold green]",
                             title="[white]System Status[/white]",
-                            subtitle=f"Model: {GEMINI_MODEL_NAME} | MCP Server: {'[bold green]Running[/bold green]' if mcp_client.is_alive() else '[bold red]Failed[/bold red]'}"))
+                            subtitle=f"{active_model_display} | MCP Server: {'[bold green]Running[/bold green]' if mcp_client.is_alive() else '[bold red]Failed[/bold red]'}"))
+
         if not mcp_client.is_alive():
             console.print(Panel("[bold red]MCP Server failed to start. Please check the logs and try restarting the broker.[/bold red]", title="[red]Critical Error[/red]"))
             return
 
-        console.print("Type your commands for Roblox Studio, or 'exit' to quit.", style="dim")
-
-
-        parser = argparse.ArgumentParser(description="Roblox Studio Gemini Broker")
-        parser.add_argument("--test_command", type=str, help="Execute a single test command and exit.")
-        parser.add_argument('--test_file', type=str, help='Path to a file containing a list of test commands, one per line.')
-        args = parser.parse_args()
-
+        # args are already parsed globally now
         if args.test_file:
-            console.print(f"\n[bold yellow]>>> Test File Mode: '{args.test_file}' <<<[/bold yellow]")
+            console.print(f"\n[bold yellow]>>> Test File Mode: '{args.test_file}' ({LLM_PROVIDER.capitalize()}) <<<[/bold yellow]")
             file_command_errors = 0
             file_command_total = 0
             try:
                 with open(args.test_file, 'r') as f:
                     commands = [line.strip() for line in f if line.strip() and not line.strip().startswith('#')]
-
                 file_command_total = len(commands)
                 console.print(f"[info]Found {file_command_total} commands in the test file.[/info]")
 
                 for i, user_input_str in enumerate(commands):
                     console.print(f"\n[bold cyan]>>> Executing from file ({i+1}/{file_command_total}):[/bold cyan] {user_input_str}")
-                    if not await _process_command(user_input_str, chat_session, tool_dispatcher, console, logger, is_test_file_command=True):
-                        file_command_errors += 1
+                    process_args = {
+                        "user_input_str": user_input_str,
+                        "llm_provider": LLM_PROVIDER,
+                        "chat_session": chat_session, # This is Gemini chat or Ollama history list
+                        "tool_dispatcher": tool_dispatcher,
+                        "console": console,
+                        "logger": logger,
+                        "is_test_file_command": True
+                    }
+                    if LLM_PROVIDER == "ollama":
+                        process_args["ollama_model_name"] = OLLAMA_MODEL_NAME
+                        process_args["ollama_history"] = chat_session # Pass history for ollama
+                        process_args["chat_session"] = llm_client # Pass ollama client for ollama
+                    elif LLM_PROVIDER == "gemini":
+                         process_args["gemini_model_resource_name"] = gemini_model_resource_name
 
-                    if i < file_command_total - 1: # Don't sleep after the last command
+
+                    if not await _process_command(**process_args):
+                        file_command_errors += 1
+                    if i < file_command_total - 1:
                         console.print(f"[dim]Waiting for 25 seconds before next command...[/dim]")
                         await asyncio.sleep(25)
-
                 console.print(f"\n[bold {'green' if file_command_errors == 0 else 'red'}]>>> Test file processing complete. {file_command_total - file_command_errors}/{file_command_total} commands succeeded. <<<[/bold {'green' if file_command_errors == 0 else 'red'}]")
-
 
             except FileNotFoundError:
                 logger.error(f"Test file not found: {args.test_file}")
                 console.print(f"[bold red]Error: Test file '{args.test_file}' not found.[/bold red]")
-                file_command_errors = 1 # Indicate failure
             except Exception as e:
                 logger.error(f"Error processing test file '{args.test_file}': {e}", exc_info=True)
                 console.print(f"[bold red]An unexpected error occurred while processing the test file: {e}[/bold red]")
-                file_command_errors = file_command_total # Assume all failed if the loop was interrupted
-
-            # Regardless of errors in file processing, we want to ensure this mode exits.
             return # Exit after test file processing
 
         elif args.test_command:
             user_input_str = args.test_command
-            console.print(f"\n[bold cyan]>>> Running Test Command:[/bold cyan] {user_input_str}")
-            await _process_command(user_input_str, chat_session, tool_dispatcher, console, logger)
-            console.print("\n[bold cyan]>>> Test command finished. Exiting. <<<[/bold cyan]")
-            return # Exit after test command
+            console.print(f"\n[bold cyan]>>> Running Test Command ({LLM_PROVIDER.capitalize()}):[/bold cyan] {user_input_str}")
+            process_args = {
+                "user_input_str": user_input_str,
+                "llm_provider": LLM_PROVIDER,
+                "chat_session": chat_session, # Gemini chat or Ollama history list
+                "tool_dispatcher": tool_dispatcher,
+                "console": console,
+                "logger": logger,
+            }
+            if LLM_PROVIDER == "ollama":
+                process_args["ollama_model_name"] = OLLAMA_MODEL_NAME
+                process_args["ollama_history"] = chat_session # Pass history for ollama
+                process_args["chat_session"] = llm_client # Pass ollama client
+            elif LLM_PROVIDER == "gemini":
+                process_args["gemini_model_resource_name"] = gemini_model_resource_name
+
+            await _process_command(**process_args)
+            console.print(f"\n[bold cyan]>>> Test command finished ({LLM_PROVIDER.capitalize()}). Exiting. <<<[/bold cyan]")
+            return
 
         else: # Interactive Mode
-            console.print("Type your commands for Roblox Studio, or 'exit' to quit.", style="dim")
+            console.print(f"Type your commands for Roblox Studio ({LLM_PROVIDER.capitalize()} backend), or 'exit' to quit.", style="dim")
             while True:
                 if not mcp_client.is_alive():
                     console.print(Panel("[bold yellow]Connection to Roblox Studio lost. Attempting to reconnect...[/bold yellow]", title="[yellow]Connection Issue[/yellow]"))
@@ -356,50 +564,60 @@ async def main_loop():
                         else:
                             status_spinner.update("[bold red]Failed to reconnect.[/bold red]")
                             console.print(Panel("[bold red]Failed to reconnect to Roblox Studio after multiple attempts. Please restart Roblox Studio and the broker.[/bold red]", title="[red]Connection Failed[/red]"))
-                            break # Exit interactive loop if reconnect fails
+                            break
 
                 user_input_str = ""
                 try:
-                    prompt_text = HTML('<ansiblue><b>You: </b></ansiblue>')
+                    prompt_text = HTML(f'<ansiblue><b>You ({LLM_PROVIDER.capitalize()}): </b></ansiblue>')
                     user_input_str = await asyncio.to_thread(session.prompt, prompt_text, reserve_space_for_menu=0)
-                except KeyboardInterrupt:
-                    console.print("\n[bold yellow]Exiting broker...[/bold yellow]")
-                    break
-                except EOFError:
-                    console.print("\n[bold yellow]Exiting broker (EOF)...[/bold yellow]")
-                    break
+                except KeyboardInterrupt: console.print("\n[bold yellow]Exiting broker...[/bold yellow]"); break
+                except EOFError: console.print("\n[bold yellow]Exiting broker (EOF)...[/bold yellow]"); break
 
-                if user_input_str.lower() == 'exit':
-                    console.print("[bold yellow]Exiting broker...[/bold yellow]")
-                    break
+                if user_input_str.lower() == 'exit': console.print("[bold yellow]Exiting broker...[/bold yellow]"); break
 
-                await _process_command(user_input_str, chat_session, tool_dispatcher, console, logger)
+                process_args = {
+                    "user_input_str": user_input_str,
+                    "llm_provider": LLM_PROVIDER,
+                    "chat_session": chat_session, # Gemini chat or Ollama history
+                    "tool_dispatcher": tool_dispatcher,
+                    "console": console,
+                    "logger": logger,
+                }
+                if LLM_PROVIDER == "ollama":
+                    process_args["ollama_model_name"] = OLLAMA_MODEL_NAME
+                    process_args["ollama_history"] = chat_session # Pass history
+                    process_args["chat_session"] = llm_client # Pass ollama client
+                elif LLM_PROVIDER == "gemini":
+                    process_args["gemini_model_resource_name"] = gemini_model_resource_name
 
-    except FileNotFoundError as e: # This is for rbx-mcp-server executable
-        logger.critical(f"Setup Error: {e}")
-        console.print(Panel(f"[bold red]Setup Error:[/bold red] {e}. Ensure rbx-studio-mcp executable is built and accessible.", title="[red]Critical Error[/red]"))
+                await _process_command(**process_args)
+
+    except FileNotFoundError as e:
+        logger.critical(f"Setup Error - RBX MCP Server path: {e}")
+        console.print(Panel(f"[bold red]Setup Error:[/bold red] MCP Server executable not found at '{RBX_MCP_SERVER_PATH}'. Details: {e}. Ensure it is built and accessible.", title="[red]Critical Error[/red]"))
     except MCPConnectionError as e:
         logger.critical(f"MCP Critical Connection Error on startup: {e}")
         console.print(Panel(f"[bold red]MCP Critical Connection Error:[/bold red] {e}. Could not connect to Roblox Studio.", title="[red]Critical Error[/red]"))
     except Exception as e:
-        logger.critical(f"Critical unhandled exception in main: {e}", exc_info=True)
+        logger.critical(f"Critical unhandled exception in main_loop: {e}", exc_info=True)
         console.print(Panel(f"[bold red]Critical unhandled exception:[/bold red] {e}", title="[red]Critical Error[/red]"))
     finally:
-        # Use mcp_client_instance which is assigned after mcp_client is defined.
-        if 'mcp_client_instance' in locals() and mcp_client_instance and mcp_client_instance.is_alive():
+        if mcp_client_instance and mcp_client_instance.is_alive(): # mcp_client_instance should be mcp_client
             console.print("[bold yellow]Shutting down MCP server...[/bold yellow]")
-            await mcp_client_instance.stop() # Use the instance from the try block
-        logger.info("Broker application finished.")
-        console.print("[bold yellow]Broker application finished.[/bold yellow]")
+            await mcp_client.stop()
+        logger.info(f"Broker application finished (LLM Provider: {LLM_PROVIDER}).")
+        console.print(f"[bold yellow]Broker application finished (LLM Provider: {LLM_PROVIDER}).[/bold yellow]")
 
 if __name__ == '__main__':
+    # Args are parsed globally now, so main_loop can use them directly.
     try:
         asyncio.run(main_loop())
     except KeyboardInterrupt:
-        console.print("\n[bold red]Broker interrupted by user (Ctrl+C). Exiting...[/bold red]")
-        logger.info("Broker interrupted by user (Ctrl+C).")
+        # This might be redundant if the try/except in main_loop's interactive part catches it first.
+        console.print("\n[bold red]Broker interrupted by user (Ctrl+C globally). Exiting...[/bold red]")
+        logger.info("Broker interrupted by user (Ctrl+C globally).")
     except SystemExit as e:
-        if str(e) == "GEMINI_API_KEY not set.":
-            pass # Already handled by initial check
-        else:
-            console.print(f"\n[bold red]System exit: {e}[/bold red]")
+        # This handles sys.exit calls, e.g., from argument parsing errors or LLM init failures
+        if str(e) not in ["0", "1"] and e.code is not None : # Don't print for clean exits like sys.exit(0) or sys.exit(1) without a message
+             console.print(f"\n[bold red]System exit: {e}[/bold red]")
+        # If sys.exit was called due to GEMINI_API_KEY issue or Ollama import error, it's already logged/printed.

--- a/ollama_setup.bat
+++ b/ollama_setup.bat
@@ -1,0 +1,93 @@
+@echo OFF
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+REM --- Main Script ---
+CALL :CheckOllama
+IF "!OLLAMA_INSTALLED!"=="false" (
+    CALL :InstallGuide
+    CALL :CheckOllama
+    IF "!OLLAMA_INSTALLED!"=="false" (
+        echo.
+        echo [OLLAMA SETUP] Ollama still not found after installation attempt.
+        echo [OLLAMA SETUP] Please try restarting your terminal/command prompt, or ensure Ollama is correctly added to your system PATH.
+        CHOICE /C YN /M "[OLLAMA SETUP] Do you want to try downloading models anyway (Y/N)?"
+        IF ERRORLEVEL 2 (
+            echo [OLLAMA SETUP] Exiting setup. Please resolve Ollama installation issues.
+            GOTO :EOF
+        )
+    )
+)
+
+CALL :DownloadModels
+
+echo.
+echo [OLLAMA SETUP] Ollama setup process complete.
+echo [OLLAMA SETUP] You can now try running the agent using a batch file like 'run_ollama_agent.bat' (if available)
+echo [OLLAMA SETUP] or by running the main Python script with '--llm_provider ollama'.
+GOTO :EOF
+
+REM --- Subroutine: CheckOllama ---
+:CheckOllama
+echo.
+echo [OLLAMA SETUP] Checking for Ollama installation...
+ollama --version >NUL 2>NUL
+IF !ERRORLEVEL! EQU 0 (
+    echo [OLLAMA SETUP] Ollama is installed.
+    SET OLLAMA_INSTALLED=true
+) ELSE (
+    echo [OLLAMA SETUP] Ollama not found.
+    SET OLLAMA_INSTALLED=false
+)
+GOTO :EOF
+
+REM --- Subroutine: InstallGuide ---
+:InstallGuide
+echo.
+echo [OLLAMA SETUP] Ollama installation guide:
+echo [OLLAMA SETUP] 1. Download Ollama from: https://ollama.com/download
+echo [OLLAMA SETUP] 2. Run the installer and follow its instructions.
+echo [OLLAMA SETUP] 3. Ensure Ollama is running after installation (it usually starts automatically).
+echo.
+pause "[OLLAMA SETUP] Press any key to continue after installing Ollama..."
+GOTO :EOF
+
+REM --- Subroutine: DownloadModels ---
+:DownloadModels
+echo.
+echo [OLLAMA SETUP] Attempting to download required Ollama models...
+echo [OLLAMA SETUP] This may take some time depending on your internet connection.
+echo.
+
+SET MODEL_PHI3=phi3:mini
+SET MODEL_QWEN2_7B=qwen2:7b
+SET MODEL_QWEN2_7B_Q4=qwen2:7b-q4_K_M
+REM Using qwen2:7b-q4_K_M as q4_0 is less common. User can change if needed.
+
+echo [OLLAMA SETUP] Pulling model: !MODEL_PHI3!
+ollama pull "!MODEL_PHI3!"
+IF !ERRORLEVEL! EQU 0 (
+    echo [OLLAMA SETUP] Successfully pulled !MODEL_PHI3!.
+) ELSE (
+    echo [OLLAMA SETUP] ERROR: Failed to pull !MODEL_PHI3!. Please check your internet connection and ensure Ollama is running. (Error Code: !ERRORLEVEL!)
+)
+echo.
+
+echo [OLLAMA SETUP] Pulling model: !MODEL_QWEN2_7B!
+ollama pull "!MODEL_QWEN2_7B!"
+IF !ERRORLEVEL! EQU 0 (
+    echo [OLLAMA SETUP] Successfully pulled !MODEL_QWEN2_7B!.
+) ELSE (
+    echo [OLLAMA SETUP] ERROR: Failed to pull !MODEL_QWEN2_7B!. (Error Code: !ERRORLEVEL!)
+)
+echo.
+
+echo [OLLAMA SETUP] Pulling model: !MODEL_QWEN2_7B_Q4!
+ollama pull "!MODEL_QWEN2_7B_Q4!"
+IF !ERRORLEVEL! EQU 0 (
+    echo [OLLAMA SETUP] Successfully pulled !MODEL_QWEN2_7B_Q4!.
+) ELSE (
+    echo [OLLAMA SETUP] ERROR: Failed to pull !MODEL_QWEN2_7B_Q4!. (Error Code: !ERRORLEVEL!)
+    echo [OLLAMA SETUP] Note: If this specific quantized model is unavailable, you might try other variants like 'qwen2:7b-q5_K_M' or check the Ollama library for available tags.
+)
+echo.
+GOTO :EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ google-genai
 python-dotenv
 rich
 prompt_toolkit
+ollama

--- a/run_ollama_agent.bat
+++ b/run_ollama_agent.bat
@@ -1,0 +1,133 @@
+@echo OFF
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+REM --- Configuration ---
+SET SCRIPT_NAME=run_ollama_agent.bat
+SET PYTHON_EXE=python
+SET MAIN_SCRIPT=main.py
+SET OLLAMA_SERVICE_LOG=ollama_service.log
+SET DEFAULT_MODEL=phi3:mini
+SET STARTUP_DELAY_SECONDS=7
+
+REM --- Main Script ---
+CALL :CheckOllamaInstallation
+IF "!OLLAMA_READY!"=="false" GOTO :EOF
+
+CALL :EnsureOllamaService
+IF "!OLLAMA_SERVICE_READY!"=="false" (
+    echo.
+    echo [!SCRIPT_NAME!] The Ollama service does not seem to be responding even after an attempt to start it.
+    echo [!SCRIPT_NAME!] Please try starting the Ollama application/service manually.
+    CHOICE /C YN /M "[!SCRIPT_NAME!] Do you want to try running the agent anyway (Y/N)?"
+    IF ERRORLEVEL 2 (
+        echo [!SCRIPT_NAME!] Exiting.
+        GOTO :EOF
+    )
+)
+
+CALL :SelectOllamaModel
+IF "!SELECTED_MODEL!"=="" (
+    echo [!SCRIPT_NAME!] No model selected or invalid input. Exiting.
+    GOTO :EOF
+)
+
+CALL :RunAgent
+GOTO :EOF
+
+
+REM --- Subroutine: CheckOllamaInstallation ---
+:CheckOllamaInstallation
+SET OLLAMA_READY=false
+echo.
+echo [!SCRIPT_NAME!] Checking for Ollama installation...
+ollama --version >NUL 2>NUL
+IF !ERRORLEVEL! EQU 0 (
+    echo [!SCRIPT_NAME!] Ollama is installed.
+    SET OLLAMA_READY=true
+) ELSE (
+    echo [!SCRIPT_NAME!] Ollama installation not found.
+    echo [!SCRIPT_NAME!] Please run 'ollama_setup.bat' first to install Ollama and download models.
+)
+GOTO :EOF
+
+
+REM --- Subroutine: EnsureOllamaService ---
+:EnsureOllamaService
+SET OLLAMA_SERVICE_READY=false
+echo.
+echo [!SCRIPT_NAME!] Checking if Ollama service is running...
+ollama list >NUL 2>NUL
+IF !ERRORLEVEL! EQU 0 (
+    echo [!SCRIPT_NAME!] Ollama service is responding.
+    SET OLLAMA_SERVICE_READY=true
+    GOTO :EOF
+)
+
+echo [!SCRIPT_NAME!] Ollama service not responding. Attempting to start it...
+echo [!SCRIPT_NAME!] This may take a moment. A log file will be created: !OLLAMA_SERVICE_LOG!
+REM Starting a small model like phi3:mini in the background can help ensure the service is up.
+REM The --verbose flag can help in diagnosing issues if the log is inspected.
+START "OllamaServiceDaemon" /B ollama run !DEFAULT_MODEL! --verbose > "!OLLAMA_SERVICE_LOG!" 2>&1
+
+echo [!SCRIPT_NAME!] Waiting for !STARTUP_DELAY_SECONDS! seconds for the Ollama service to initialize...
+timeout /t !STARTUP_DELAY_SECONDS! /nobreak >NUL
+
+echo [!SCRIPT_NAME!] Re-checking Ollama service status...
+ollama list >NUL 2>NUL
+IF !ERRORLEVEL! EQU 0 (
+    echo [!SCRIPT_NAME!] Ollama service is now responding.
+    SET OLLAMA_SERVICE_READY=true
+) ELSE (
+    echo [!SCRIPT_NAME!] Ollama service still not responding.
+    echo [!SCRIPT_NAME!] Please check the log file: !OLLAMA_SERVICE_LOG!
+    echo [!SCRIPT_NAME!] You might need to start the Ollama application manually.
+    REM Note: The background 'ollama run' process might still be trying.
+    REM If it succeeds later, the agent might connect.
+)
+GOTO :EOF
+
+
+REM --- Subroutine: SelectOllamaModel ---
+:SelectOllamaModel
+SET SELECTED_MODEL=
+echo.
+echo [!SCRIPT_NAME!] Please select an Ollama model to use:
+echo   1. Phi-3 Mini (phi3:mini)
+echo   2. Qwen2 7B (qwen2:7b)
+echo   3. Qwen2 7B Quantized (qwen2:7b-q4_K_M)
+echo   4. Enter custom model name
+echo.
+
+CHOICE /C 1234 /M "[!SCRIPT_NAME!] Enter your choice (1-4): "
+SET MODEL_CHOICE=!ERRORLEVEL!
+
+IF "!MODEL_CHOICE!"=="1" SET SELECTED_MODEL=phi3:mini
+IF "!MODEL_CHOICE!"=="2" SET SELECTED_MODEL=qwen2:7b
+IF "!MODEL_CHOICE!"=="3" SET SELECTED_MODEL=qwen2:7b-q4_K_M
+IF "!MODEL_CHOICE!"=="4" (
+    echo.
+    SET /P "CUSTOM_MODEL=[!SCRIPT_NAME!] Enter the custom Ollama model name (e.g., mistral:latest): "
+    IF DEFINED CUSTOM_MODEL (
+        SET SELECTED_MODEL=!CUSTOM_MODEL!
+    ) ELSE (
+        echo [!SCRIPT_NAME!] No custom model name entered.
+        SET SELECTED_MODEL=
+    )
+)
+
+IF DEFINED SELECTED_MODEL (
+    echo [!SCRIPT_NAME!] Using model: !SELECTED_MODEL!
+)
+GOTO :EOF
+
+
+REM --- Subroutine: RunAgent ---
+:RunAgent
+echo.
+echo [!SCRIPT_NAME!] Starting the AI agent with Ollama model: !SELECTED_MODEL!
+echo [!SCRIPT_NAME!] Command: !PYTHON_EXE! !MAIN_SCRIPT! --llm_provider ollama --ollama_model "!SELECTED_MODEL!"
+echo.
+"!PYTHON_EXE!" "!MAIN_SCRIPT!" --llm_provider ollama --ollama_model "!SELECTED_MODEL!"
+echo.
+echo [!SCRIPT_NAME!] Agent execution finished.
+GOTO :EOF


### PR DESCRIPTION
This change introduces the capability to use local LLMs via Ollama as an alternative to the Gemini API.

Key features:
- Added `ollama` Python library dependency.
- Updated `config_manager.py` to include Ollama settings (API URL, default model, LLM provider choice).
- Modified `main.py` to support an `--llm_provider` (gemini/ollama) and `--ollama_model` CLI arguments, and to use the Ollama client for chat and tool calls if selected.
- Adapted `gemini_tools.py` to support Ollama tool calls by introducing a generic `FunctionCall` dataclass and a function to convert tool definitions to Ollama-compatible JSON schema.
- Updated `console_ui.py` for generic provider console messages.
- Created `ollama_setup.bat` to guide you through Ollama installation and download of standard models (phi3:mini, qwen2:7b, qwen2:7b-q4_K_M).
- Created `run_ollama_agent.bat` to facilitate running the agent with Ollama, including model selection.
- Updated `README.md` with comprehensive instructions for the new Ollama workflow, configuration, and CLI options.