### PR TITLE
Fix: Correct IndentationError in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -137,10 +137,13 @@ async def _process_command(
         while current_retry_attempt < MAX_API_RETRIES:
             try:
                 if current_retry_attempt > 0:
+                    # Common delay logic for retries, message customized by provider
+                    delay_message_provider = "Gemini" if llm_provider == "gemini" else "Ollama"
+                    with console.status(f"[bold yellow]{delay_message_provider} API error. Retrying in {current_delay:.1f}s (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES})...[/bold yellow]", spinner="dots") as status_spinner_retry:
+                        await asyncio.sleep(current_delay)
+
+                # API call logic properly indented under the try block
                 if llm_provider == "gemini":
-                    if current_retry_attempt > 0:
-                        with console.status(f"[bold yellow]Gemini API error. Retrying in {current_delay:.1f}s (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES})...[/bold yellow]", spinner="dots") as status_spinner_gemini_retry:
-                            await asyncio.sleep(current_delay)
                     with console.status(f"[bold green]Gemini is thinking... (Attempt {current_retry_attempt + 1})[/bold green]", spinner="dots") as status_spinner_gemini:
                         response = await chat_session.send_message( # chat_session is the Gemini chat
                             message=user_input_str,
@@ -148,10 +151,6 @@ async def _process_command(
                         )
                     break # Success
                 elif llm_provider == "ollama":
-                    # Ollama doesn't have explicit retries in the same way, but we can implement a similar loop
-                    if current_retry_attempt > 0:
-                        with console.status(f"[bold yellow]Ollama API error. Retrying in {current_delay:.1f}s (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES})...[/bold yellow]", spinner="dots") as status_spinner_ollama_retry:
-                            await asyncio.sleep(current_delay)
                     with console.status(f"[bold green]Ollama is thinking... (Attempt {current_retry_attempt + 1})[/bold green]", spinner="dots") as status_spinner_ollama:
                         # Add user message to history
                         ollama_history.append({'role': 'user', 'content': user_input_str})
@@ -171,7 +170,8 @@ async def _process_command(
                     break # Success for Ollama
 
             except ServerError as e: # Gemini specific
-                if llm_provider == "gemini":
+                # This exception block is now correctly aligned with the try block
+                if llm_provider == "gemini": # Check provider again here for provider-specific error handling
                     logger.warning(f"Gemini API ServerError (Attempt {current_retry_attempt + 1}/{MAX_API_RETRIES}): {e}")
                     current_retry_attempt += 1
                     if current_retry_attempt >= MAX_API_RETRIES:


### PR DESCRIPTION
I resolved an IndentationError in the `_process_command` function within `main.py`. The error was caused by incorrect nesting of conditional statements related to LLM provider logic and retry attempts.

I restructured the try-except block to correctly indent the provider-specific API call logic and consolidated the retry delay handling.