### PR TITLE
Fix: Handle null arguments in Ollama tool calls

### DIFF
--- a/main.py
+++ b/main.py
@@ -287,7 +287,10 @@ async def _process_command(
                                         else:
                                             logger.info(f"Identified potential tool call from content: '{fc_name}'")
 
-                                            if isinstance(fc_args, str):
+                                            # MODIFIED SECTION START
+                                            if fc_args is None:
+                                                fc_args = {}
+                                            elif isinstance(fc_args, str):
                                                 try:
                                                     fc_args = json.loads(fc_args)
                                                 except json.JSONDecodeError as e_inner:
@@ -295,10 +298,11 @@ async def _process_command(
                                                     continue
 
                                             if not isinstance(fc_args, dict):
-                                                logger.warning(f"Ollama tool call from content for '{fc_name}' has 'arguments' not as dict or parsable string: {type(fc_args)}. Skipping.")
+                                                logger.warning(f"Ollama tool call from content for '{fc_name}' has 'arguments' not as dict or parsable string (and not None): {type(fc_args)}. Skipping.")
                                                 continue
+                                            # MODIFIED SECTION END
 
-                                            pending_function_calls.append(FunctionCall(id=None, name=fc_name, args=fc_args)) # id will be None
+                                            pending_function_calls.append(FunctionCall(id=None, name=fc_name, args=fc_args))
                                             logger.info(f"Appended tool call from 'content' JSON: {fc_name} with args {fc_args}")
                                     else:
                                         logger.info("Ollama content JSON (after potential Markdown stripping) does not match expected tool call structure (name/function_name + arguments keys). Treating as text.")

--- a/ollama_test_commands.txt
+++ b/ollama_test_commands.txt
@@ -1,4 +1,3 @@
-
 # Comprehensive Test Suite for Luau Tools
 
 # --- Section 1: Instance Creation and Basic Properties (CreateInstance, GetInstanceProperties, SetInstanceProperties, delete_instance) ---
@@ -244,3 +243,8 @@ RunCode command="print('Simple Game: Obby construction commands complete.')"
 # A more robust cleanup would use GetInstancesWithTag and loop delete, but that's too complex for test_commands.txt itself.
 # The individual delete tests already cover functionality.
 
+# --- Section 9: Test for Null Arguments in Tool Calls ---
+# This command is intended to see if the LLM might call CreateInstance (or another tool)
+# with 'null' or missing arguments if the properties are not well-defined by the prompt.
+# The recent fix in main.py should handle fc_args being None by converting it to {}.
+Create a new part with default settings.


### PR DESCRIPTION
Ollama tool calls with `null` arguments were being skipped due to a type check expecting a dictionary. This commit modifies the parsing logic in `main.py` to treat `null` arguments as an empty dictionary, allowing these tool calls to be processed correctly.

A test case has been added to `ollama_test_commands.txt` to verify this fix.