### PR TITLE
Fix Ollama interaction looping and log spam

### DIFF
--- a/mcp_client.py
+++ b/mcp_client.py
@@ -221,7 +221,7 @@ class MCPClient:
             try:
                 line_bytes = await asyncio.wait_for(self.process.stderr.readline(), timeout=5.0)
                 if not line_bytes: logger.info("MCP stderr EOF."); break
-                logger.warning(f"[MCP STDERR]: {line_bytes.decode('utf-8').strip()}")
+                logger.info(f"[MCP STDERR]: {line_bytes.decode('utf-8').strip()}")
             except asyncio.TimeoutError:
                 if not (self.process and self.process.returncode is None):
                     logger.warning("MCP stderr readline timed out and process is no longer running."); break


### PR DESCRIPTION
This commit addresses two main issues:
1.  The agent getting stuck in an interaction loop with Ollama.
2.  Excessive WARNING messages from the state_manager client.

Changes:
- Modified `main.py` to improve how interaction results are formatted for Ollama. If an interaction returns a simple success message (e.g., `{"content": "message"}`), the actual "message" string is now passed directly to Ollama, rather than a JSON dump of the containing object. This aims to provide clearer feedback to the LLM.
- Enhanced `main.py` to more robustly handle cases where Ollama exceeds `MAX_CONSECUTIVE_INTERACTIONS`. If Ollama attempts to issue another interaction immediately after the intervention message, I now explicitly halt processing for that command and notify you, preventing the execution of the unwanted interaction.
- Changed the log level in `mcp_client.py` for messages read from the server's stderr (specifically the "No tasks in queue..." messages) from WARNING to INFO. This reduces console noise from normal idle server behavior.