### PR TITLE
I've enhanced the logging for Ollama tool calls from the content field.

### DIFF
--- a/main.py
+++ b/main.py
@@ -290,8 +290,8 @@ async def _process_command(
                                         fc_name = potential_tool_call.get('name') or potential_tool_call.get('function_name')
                                         fc_args = potential_tool_call['arguments']
 
-                                        if not fc_name: # Safeguard, though covered by the condition above
-                                            logger.warning("Tool call from content JSON is missing 'name' or 'function_name'. Skipping.")
+                                        if not fc_name:
+                                            logger.warning(f"Tool call from content JSON is missing a valid 'name' or 'function_name'. Full potential tool call dictionary: {potential_tool_call}. Skipping.")
                                             continue
                                         else:
                                             logger.info(f"Identified potential tool call from content: '{fc_name}'")


### PR DESCRIPTION
I modified main.py to log the entire `potential_tool_call` dictionary when a function name ('name' or 'function_name') is missing or null in Ollama responses parsed from the content field.

This will provide you with more detailed information for diagnosing issues with how Ollama communicates tool call intentions, particularly when it doesn't use the explicit 'tool_calls' array and instead embeds JSON in the 'content' string.