### PR TITLE
Input:

### DIFF
--- a/main.py
+++ b/main.py
@@ -604,42 +604,16 @@ async def main_loop():
 
             # Ollama uses a list of messages for history.
             # The system prompt for Ollama might need different formatting or content.
-            # For now, using a similar system prompt.
             ollama_system_prompt = (
-                "You are an expert AI assistant for Roblox Studio. Your primary goal is to help users by using the provided tools to interact with their game development environment. "
-                "Follow these instructions meticulously:\n\n"
-
-                "CRITICAL: Adhere STRICTLY to the provided tool list and schemas. DO NOT invent tool names or argument names. Any deviation will result in failure.\n\n"
-                "1.  **Analyze and Plan:** Think step-by-step about the user's request before acting.\n\n"
-                "2.  **Tool Usage - CRITICAL Adherence:** You MUST ONLY use tools explicitly provided in the tool list. Refer to this list for available tools and their exact defined arguments. "
-                "Tool names and argument names are case-sensitive and must match the schema EXACTLY. "
-                "Do NOT invent tool names (e.g., `setProperty`, `log_error`, `create_new_property` are INVALID if not listed). "
-                "Example of WRONG behavior: If `CreateInstance` tool exists, DO NOT try to use `create_part` or `add_new_object`. Use `CreateInstance`."
-                "Use the exact argument names specified in the schema for each tool (e.g., if the schema says `class_name`, do not use `className` or `instance_type` unless specified as an alternative in the description). "
-                "Example of WRONG argument: If a tool expects `instance_path`, DO NOT use `path` or `target_object` unless the schema explicitly lists it as an alternative. "
-
-                "Provide arguments in the correct format as per the schema description (e.g. Vector3 as `{'x':0,'y':0,'z':0}`, Enums as `Enum.Value.Name`).\n\n"
-                "3.  **Error Handling Protocol:** If a tool call results in an error, you MUST analyze the error message provided in the tool's response. "
-                "DO NOT immediately retry the exact same tool call with the exact same arguments. "
-                "First, summarize the nature of the error to the user in your text response. "
-                "If, and only if, you can confidently correct the arguments based on the error message and the tool's schema (e.g., fixing a path, a data type, or an invalid value format), you may try the corrected tool call ONCE. "
-                "If you are unsure how to fix it, or if the error persists after one correction attempt, DO NOT try again. Instead, explain the persistent error and ask the user for clarification or guidance. "
-
-                "Absolutely DO NOT attempt to call a 'log_error', 'error_handler', or any other tool name that is not explicitly in the provided list of available tools to handle errors.\n"
-                "    Example Error Scenario:\n"
-                "    User asks: 'Create a green part named MyPart.'\n"
-                "    You call: `CreateInstance(class_name='Part', properties={'Name':'MyPart', 'Color':'Green'})`\n"
-                "    Tool Error: 'Invalid Color property. Expected Color3 dictionary like {r:0, g:1, b:0}, got string.'\n"
-                "    CORRECT next action: 'I tried to create the part, but the color 'Green' was not in the correct format. Should I use a Color3 dictionary like `{'r':0, 'g':0.5, 'b':0}` for green?' OR summarize and ask for a valid Color3.\n"
-                "    INCORRECT next action: Calling `CreateInstance` again with `Color:'Green'` OR calling an invented tool like `SetColor(target='MyPart', color='Green')`.\n\n"
-
-                "4.  **Clarification:** If a user's request is ambiguous, or if you are unsure how to proceed after an error, ask the user clarifying questions.\n\n"
-                "5.  **Summarize Results:** After a tool is used successfully, summarize the outcome for the user in a clear, concise way.\n\n"
-                "6.  **Loop Prevention & Progress:** Avoid getting stuck in loops of repeated tool calls, especially if they are failing or not making clear progress. "
-                "If you've made an attempt (e.g., a tool call that resulted in an error you couldn't confidently fix, as per point #3), and you are still unsure how to proceed, STOP. "
-                "Explain what you tried, what happened, and ask the user for guidance. Do not just try another variant of the failed call without new information or a very high degree of confidence in the correction.\n\n"
-                "7.  **Environmental Awareness:** You cannot see the screen, the game world, or the project explorer in Roblox Studio. "
-                "Rely SOLELY on the information provided in tool outputs to understand the current state of the environment. Do not make assumptions about instance existence or properties without verifying through tools."
+                "You are an AI assistant for Roblox Studio. Use tools to interact with the game development environment. "
+                "Analyze requests, then call tools with correct arguments.\n\n"
+                "IMPORTANT: If you need to use a tool, your response MUST BE ONLY a JSON object for the tool call. "
+                "Do not add any other text before or after the JSON. "
+                "The JSON should be a single object with 'name' (or 'function_name') and 'arguments' keys. Example: "
+                "{{\"name\": \"ToolName\", \"arguments\": {{\"arg1\": \"value1\"}}}}\n\n"
+                "Ensure tool names and arguments match the provided schema exactly.\n\n"
+                "Error Handling: If a tool call fails, analyze the error. If you can fix it, try ONCE. Otherwise, explain the error and ask the user for guidance. Do not invent error handling tools.\n\n"
+                "Progress: If unsure or stuck, explain what you tried and ask the user for guidance. Do not repeat failed calls."
             )
             chat_session = [{'role': 'system', 'content': ollama_system_prompt}] # This is the history for Ollama
             logger.info(f"Ollama client initialized. Target model: {OLLAMA_MODEL_NAME}. System prompt set.")


### PR DESCRIPTION
Modify Ollama system prompt for phi4-mini tool calling

This change makes the Ollama system prompt more concise and direct, with a stronger emphasis on returning only JSON for tool calls. This is intended to improve the reliability of tool usage with the phi4-mini model. Output:
I've refined the Ollama system prompt to be more concise and direct, particularly regarding how I handle tool calls. This should help me use the phi4-mini model more reliably.