### PR TITLE
Add scripts and docs for phi4-mini function calling setup

### DIFF
--- a/docs/phi4_setup.md
+++ b/docs/phi4_setup.md
@@ -1,0 +1,205 @@
+# Setting up phi4-mini for Reliable Function Calling
+
+## Introduction
+
+Microsoft's `phi4-mini` language model has shown promise for function calling tasks. However, to ensure reliable and consistent behavior, especially for its `functools` style output, it's recommended to use a custom Ollama Modelfile. This setup configures the model's template to explicitly guide its output format for tool calls.
+
+This guide will walk you through creating a custom Modelfile for `phi4-mini` and making it available in Ollama.
+
+## Detailed Steps
+
+### 1. Create the Modelfile
+
+You'll need to create a new file named `phi4_fc_ollama.Modelfile` (or any other name, but be consistent). This file defines how Ollama should serve the `phi4-mini` model, including a custom template for function calling.
+
+**Modelfile Content:**
+
+```modelfile
+FROM phi4-mini:latest
+# Note: If your base model is named differently (e.g., after a specific download),
+# change 'phi4-mini:latest' to match the name you see in 'ollama list'.
+
+# Template for phi4-mini to encourage functools format
+TEMPLATE """<|user|>
+{{ .Prompt }}<|end|>
+<|assistant|>
+{{if .ToolCalls }}functools[{{ range $idx, $tool := .ToolCalls }}
+ {
+  "name": "{{$tool.Function.Name}}",
+  "arguments": {{$tool.Function.Arguments}}
+ }{{end}}
+]{{else}}{{ .Response }}{{end}}<|end|>
+"""
+
+SYSTEM """You are a helpful AI assistant.
+You have access to the following tools:
+{{ range .Tools }}
+<tool_name>
+{{ .Name }}
+</tool_name>
+<tool_description>
+{{ .Description }}
+</tool_description>
+<tool_parameters>
+{{ .Parameters }}
+</tool_parameters>
+{{ end }}
+When you need to use a tool, respond with a JSON object in the following format inside `functools[...]`:
+`functools[{"name": "<tool_name>", "arguments": {"<param_name>": "<param_value>"}}]`
+If you need to use multiple tools, include them in the list:
+`functools[{"name": "<tool_name_1>", "arguments": {...}}, {"name": "<tool_name_2>", "arguments": {...}}]`
+Only respond with the `functools[...]` structure if a tool is being called. Do not add any other text before or after it.
+If no tool is needed, respond with a regular text message.
+"""
+
+# Recommended Parameters (adjust as needed)
+PARAMETER stop "<|end|>"
+PARAMETER stop "<|user|>"
+PARAMETER stop "<|assistant|>"
+PARAMETER stop "functools["
+```
+
+**Creating the file:**
+
+You can create this file using any text editor. Alternatively, you can use command-line methods:
+
+*   **PowerShell:**
+    ```powershell
+    $modelfileContent = @"
+    FROM phi4-mini:latest
+    # Note: If your base model is named differently (e.g., after a specific download),
+    # change 'phi4-mini:latest' to match the name you see in 'ollama list'.
+
+    # Template for phi4-mini to encourage functools format
+    TEMPLATE """<|user|>
+    {{ .Prompt }}<|end|>
+    <|assistant|>
+    {{if .ToolCalls }}functools[{{ range $idx, $tool := .ToolCalls }}
+     {
+      "name": "{{$tool.Function.Name}}",
+      "arguments": {{$tool.Function.Arguments}}
+     }{{end}}
+    ]{{else}}{{ .Response }}{{end}}<|end|>
+    """
+
+    SYSTEM """You are a helpful AI assistant.
+    You have access to the following tools:
+    {{ range .Tools }}
+    <tool_name>
+    {{ .Name }}
+    </tool_name>
+    <tool_description>
+    {{ .Description }}
+    </tool_description>
+    <tool_parameters>
+    {{ .Parameters }}
+    </tool_parameters>
+    {{ end }}
+    When you need to use a tool, respond with a JSON object in the following format inside `functools[...]`:
+    `functools[{"name": "<tool_name>", "arguments": {"<param_name>": "<param_value>"}}]`
+    If you need to use multiple tools, include them in the list:
+    `functools[{"name": "<tool_name_1>", "arguments": {...}}, {"name": "<tool_name_2>", "arguments": {...}}]`
+    Only respond with the `functools[...]` structure if a tool is being called. Do not add any other text before or after it.
+    If no tool is needed, respond with a regular text message.
+    """
+
+    # Recommended Parameters (adjust as needed)
+    PARAMETER stop "<|end|>"
+    PARAMETER stop "<|user|>"
+    PARAMETER stop "<|assistant|>"
+    PARAMETER stop "functools["
+    "@
+    Set-Content -Path "./phi4_fc_ollama.Modelfile" -Value $modelfileContent
+    ```
+
+*   **Bash (Linux/macOS/WSL):**
+    ```bash
+    cat << EOF > ./phi4_fc_ollama.Modelfile
+    FROM phi4-mini:latest
+    # Note: If your base model is named differently (e.g., after a specific download),
+    # change 'phi4-mini:latest' to match the name you see in 'ollama list'.
+
+    # Template for phi4-mini to encourage functools format
+    TEMPLATE """<|user|>
+    {{ .Prompt }}<|end|>
+    <|assistant|>
+    {{if .ToolCalls }}functools[{{ range $idx, $tool := .ToolCalls }}
+     {
+      "name": "{{$tool.Function.Name}}",
+      "arguments": {{$tool.Function.Arguments}}
+     }{{end}}
+    ]{{else}}{{ .Response }}{{end}}<|end|>
+    """
+
+    SYSTEM """You are a helpful AI assistant.
+    You have access to the following tools:
+    {{ range .Tools }}
+    <tool_name>
+    {{ .Name }}
+    </tool_name>
+    <tool_description>
+    {{ .Description }}
+    </tool_description>
+    <tool_parameters>
+    {{ .Parameters }}
+    </tool_parameters>
+    {{ end }}
+    When you need to use a tool, respond with a JSON object in the following format inside `functools[...]`:
+    `functools[{"name": "<tool_name>", "arguments": {"<param_name>": "<param_value>"}}]`
+    If you need to use multiple tools, include them in the list:
+    `functools[{"name": "<tool_name_1>", "arguments": {...}}, {"name": "<tool_name_2>", "arguments": {...}}]`
+    Only respond with the `functools[...]` structure if a tool is being called. Do not add any other text before or after it.
+    If no tool is needed, respond with a regular text message.
+    """
+
+    # Recommended Parameters (adjust as needed)
+    PARAMETER stop "<|end|>"
+    PARAMETER stop "<|user|>"
+    PARAMETER stop "<|assistant|>"
+    PARAMETER stop "functools["
+    EOF
+    ```
+
+### 2. Create the Custom Ollama Model
+
+Once the Modelfile is created, open your terminal and run the `ollama create` command. This command packages your model with the custom settings.
+
+*   **Replace `<path_to_modelfile>` with the actual path to your `phi4_fc_ollama.Modelfile`**.
+    *   If it's in the current directory, you can use `./phi4_fc_ollama.Modelfile` (for PowerShell/bash) or `phi4_fc_ollama.Modelfile` (for cmd).
+
+*   **PowerShell:**
+    ```powershell
+    ollama create phi4-mini-functools -f ./phi4_fc_ollama.Modelfile
+    ```
+
+*   **Command Prompt (cmd):**
+    ```cmd
+    ollama create phi4-mini-functools -f phi4_fc_ollama.Modelfile
+    ```
+
+*   **Bash (Linux/macOS/WSL):**
+    ```bash
+    ollama create phi4-mini-functools -f ./phi4_fc_ollama.Modelfile
+    ```
+
+This command might take a few moments to complete. Ollama will import the base model (if not already present) and apply your custom template and parameters.
+
+### 3. Using the Custom Model with the Agent
+
+After the `ollama create` command succeeds, you will have a new model named `phi4-mini-functools` (or whatever you named it) available in Ollama.
+
+To use this with your agent (e.g., the Roblox Studio AI Broker):
+1.  Update your agent's configuration (e.g., `config.json` or command-line arguments) to specify `phi4-mini-functools` as the Ollama model name.
+    *   For example, if using command-line arguments: `--ollama_model phi4-mini-functools`
+2.  Relaunch your agent. It should now use the customized `phi4-mini` model, which is better suited for function calling.
+
+## Troubleshooting
+
+*   **`ollama create` fails:**
+    *   Double-check the path to your Modelfile.
+    *   Ensure the `FROM` line in your Modelfile correctly references a `phi4-mini` base model that you have pulled or is available (e.g., `phi4-mini:latest`). You can see your available models with `ollama list`.
+    *   Inspect the Ollama server logs for more detailed error messages. The location of these logs can vary by operating system.
+*   **Model doesn't use `functools`:**
+    *   Verify that the `phi4-mini-functools` model is actually being used by your agent.
+    *   Ensure the `TEMPLATE` and `SYSTEM` prompts in your Modelfile were copied exactly as provided. Even small deviations can affect behavior.
+    *   The `PARAMETER stop "functools["` line is important to help the model stop generating after starting the functools block, but other factors in the prompt also guide it.

--- a/run_ollama_agent.bat
+++ b/run_ollama_agent.bat
@@ -123,21 +123,22 @@ REM --- Subroutine: SelectOllamaModel ---
 SET SELECTED_MODEL=
 echo.
 echo [!SCRIPT_NAME!] Please select an Ollama model to use:
-echo   1. Phi-4 Mini (phi4-mini)
-echo   2. Qwen2.5 7B (qqwen2.5-coder:7b)
-echo   3. Qwen2.5 7B Quantized (qwen2.5-coder:7b-instruct-q4_K_M)
-echo   4. Enter custom model name
+echo   1. Phi-4 Mini - Function Calling (phi4-mini-functools) (Recommended if you ran setup_phi4_fc_model.bat)
+echo   2. Phi-4 Mini - Standard (phi4-mini)
+echo   3. Qwen2.5 7B (qwen2.5-coder:7b)
+echo   4. Qwen2.5 7B Quantized (qwen2.5-coder:7b-instruct-q4_K_M)
+echo   5. Enter custom model name
 echo.
 
-CHOICE /C 1234 /M "[!SCRIPT_NAME!] Enter your choice (1-4): "
+CHOICE /C 12345 /M "[!SCRIPT_NAME!] Enter your choice (1-5): "
 SET MODEL_CHOICE=!ERRORLEVEL!
 
-IF "!MODEL_CHOICE!"=="1" SET SELECTED_MODEL=phi4-mini
+IF "!MODEL_CHOICE!"=="1" SET SELECTED_MODEL=phi4-mini-functools
+IF "!MODEL_CHOICE!"=="2" SET SELECTED_MODEL=phi4-mini
+IF "!MODEL_CHOICE!"=="3" SET SELECTED_MODEL=qwen2.5-coder:7b
+IF "!MODEL_CHOICE!"=="4" SET SELECTED_MODEL=qwen2.5-coder:7b-instruct-q4_K_M
 
-IF "!MODEL_CHOICE!"=="2" SET SELECTED_MODEL=qwen2.5-coder:7b
-IF "!MODEL_CHOICE!"=="3" SET SELECTED_MODEL=qwen2.5-coder:7b-instruct-q4_K_M
-
-IF "!MODEL_CHOICE!"=="4" (
+IF "!MODEL_CHOICE!"=="5" (
     echo.
     SET /P "CUSTOM_MODEL=[!SCRIPT_NAME!] Enter the custom Ollama model name (e.g., mistral:latest): "
     IF DEFINED CUSTOM_MODEL (

--- a/setup_phi4_fc_model.bat
+++ b/setup_phi4_fc_model.bat
@@ -1,0 +1,93 @@
+@echo off
+setlocal
+
+:: Script to automate the creation of a custom Ollama model for phi4-mini
+:: configured for reliable function calling.
+
+:: --- Configuration ---
+set MODFILE_NAME=phi4_fc_ollama.Modelfile
+set CUSTOM_MODEL_NAME=phi4-mini-functools
+set BASE_MODEL_NAME=phi4-mini:latest
+
+echo Creating Modelfile: %MODFILE_NAME%
+echo.
+
+:: --- Create the Modelfile ---
+:: Overwrite if exists, then append
+echo FROM %BASE_MODEL_NAME% > %MODFILE_NAME%
+echo # Note: If your base model is named differently (e.g., after a specific download),^ >> %MODFILE_NAME%
+echo # change '%BASE_MODEL_NAME%' above to match the name you see in 'ollama list'.^ >> %MODFILE_NAME%
+echo. >> %MODFILE_NAME%
+echo # Template for phi4-mini to encourage functools format^ >> %MODFILE_NAME%
+echo TEMPLATE ^"""^<\|user\|^\> >> %MODFILE_NAME%
+echo {{ .Prompt }}^<\|end\|^\> >> %MODFILE_NAME%
+echo ^<\|assistant\|^\> >> %MODFILE_NAME%
+echo {{if .ToolCalls }}functools[{{ range $idx, $tool := .ToolCalls }}^ >> %MODFILE_NAME%
+echo  {^ >> %MODFILE_NAME%
+echo   "name": "{{$tool.Function.Name}}",^ >> %MODFILE_NAME%
+echo   "arguments": {{$tool.Function.Arguments}}^ >> %MODFILE_NAME%
+echo  }{{end}}^ >> %MODFILE_NAME%
+echo ]{{else}}{{ .Response }}{{end}}^<\|end\|^\>^ >> %MODFILE_NAME%
+echo """ >> %MODFILE_NAME%
+echo. >> %MODFILE_NAME%
+echo SYSTEM ^"""You are a helpful AI assistant.^ >> %MODFILE_NAME%
+echo You have access to the following tools:^ >> %MODFILE_NAME%
+echo {{ range .Tools }}^ >> %MODFILE_NAME%
+echo ^<tool_name^\>^ >> %MODFILE_NAME%
+echo {{ .Name }}^ >> %MODFILE_NAME%
+echo ^</tool_name^\>^ >> %MODFILE_NAME%
+echo ^<tool_description^\>^ >> %MODFILE_NAME%
+echo {{ .Description }}^ >> %MODFILE_NAME%
+echo ^</tool_description^\>^ >> %MODFILE_NAME%
+echo ^<tool_parameters^\>^ >> %MODFILE_NAME%
+echo {{ .Parameters }}^ >> %MODFILE_NAME%
+echo ^</tool_parameters^\>^ >> %MODFILE_NAME%
+echo {{ end }}^ >> %MODFILE_NAME%
+echo When you need to use a tool, respond with a JSON object in the following format inside `functools[...]`:`^ >> %MODFILE_NAME%
+echo `functools[{"name": "^<tool_name^>", "arguments": {"^<param_name^>": "^<param_value^>"}}]`^ >> %MODFILE_NAME%
+echo If you need to use multiple tools, include them in the list:^ >> %MODFILE_NAME%
+echo `functools[{"name": "^<tool_name_1^>", "arguments": {...}}, {"name": "^<tool_name_2^>", "arguments": {...}}]`^ >> %MODFILE_NAME%
+echo Only respond with the `functools[...]` structure if a tool is being called. Do not add any other text before or after it.^ >> %MODFILE_NAME%
+echo If no tool is needed, respond with a regular text message.^ >> %MODFILE_NAME%
+echo """ >> %MODFILE_NAME%
+echo. >> %MODFILE_NAME%
+echo # Recommended Parameters (adjust as needed)^ >> %MODFILE_NAME%
+echo PARAMETER stop "^<\|end\|^\>" >> %MODFILE_NAME%
+echo PARAMETER stop "^<\|user\|^\>" >> %MODFILE_NAME%
+echo PARAMETER stop "^<\|assistant\|^\>" >> %MODFILE_NAME%
+echo PARAMETER stop "functools[" >> %MODFILE_NAME%
+
+echo Modelfile %MODFILE_NAME% created successfully.
+echo.
+
+:: --- Run ollama create ---
+echo Running ollama create for %CUSTOM_MODEL_NAME%...
+echo This may take a few moments.
+ollama create %CUSTOM_MODEL_NAME% -f %MODFILE_NAME%
+
+:: --- Check for errors ---
+if errorlevel 1 (
+    echo.
+    echo [ERROR] 'ollama create' command failed.
+    echo Please check the output above for error messages from Ollama.
+    echo Ensure Ollama is running and the base model '%BASE_MODEL_NAME%' is available (run 'ollama list').
+    echo You can also check Ollama server logs for more details.
+    goto :eof
+)
+
+echo.
+echo Successfully created Ollama model: %CUSTOM_MODEL_NAME%
+echo.
+echo --- Next Steps ---
+echo 1. If you are using this with an agent (like the Roblox Studio AI Broker),
+echo    update its configuration to use the model name: %CUSTOM_MODEL_NAME%
+echo    (e.g., via command-line argument '--ollama_model %CUSTOM_MODEL_NAME%' or in a config file).
+echo 2. Relaunch your agent.
+echo.
+echo The Modelfile (%MODFILE_NAME%) has been left in the current directory.
+echo You can delete it if you no longer need it, or keep it for reference.
+
+endlocal
+:eof
+echo.
+pause


### PR DESCRIPTION
This commit introduces:
- docs/phi4_setup.md: Documentation explaining how to configure phi4-mini with a custom Modelfile in Ollama for reliable function calling using the functools template.
- setup_phi4_fc_model.bat: A Windows batch script to automate the creation of the custom Modelfile and the corresponding 'phi4-mini-functools' Ollama model entry.
- Modified run_ollama_agent.bat: Updated the model selection menu to include 'phi4-mini-functools' as a clear option.

These changes aim to simplify the setup process for using phi4-mini's function calling capabilities with this project.