### PR TITLE
Fix: Prevent setup_phi4_fc_model.bat from deleting source Modelfile

### DIFF
--- a/phi4_fc_ollama.Modelfile
+++ b/phi4_fc_ollama.Modelfile
@@ -18,6 +18,447 @@ TEMPLATE """
 SYSTEM """
 You are a helpful AI assistant.
 You have access to the following tools:
+^<tool_name^\>
+AddDebrisItem
+^</tool_name^\>
+^<tool_description^\>
+Adds an item to the Debris service, causing it to be destroyed after a specified lifetime.
+^</tool_description^\>
+^<tool_parameters^\>
+{"instance_path": "string", "lifetime": "number"}
+^</tool_parameters^\>
+^<tool_name^\>
+AddTag
+^</tool_name^\>
+^<tool_description^\>
+Adds a tag to an instance.
+^</tool_description^\>
+^<tool_parameters^\>
+{"instance_path": "string", "tag_name": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+CallInstanceMethod
+^</tool_name^\>
+^<tool_description^\>
+Calls a method on an instance with specified arguments.
+^</tool_description^\>
+^<tool_parameters^\>
+{"path": "string", "method_name": "string", "arguments": "array"}
+^</tool_parameters^\>
+^<tool_name^\>
+ComputePath
+^</tool_name^\>
+^<tool_description^\>
+Computes a path between two points for an agent.
+^</tool_description^\>
+^<tool_parameters^\>
+{"start_position": {"x":"number","y":"number","z":"number"}, "end_position": {"x":"number","y":"number","z":"number"}, "agent_parameters": {"AgentRadius":"number?", "AgentHeight":"number?", "AgentCanJump":"boolean?", "WaypointSpacing":"number?", "Costs":"object?"}}
+^</tool_parameters^\>
+^<tool_name^\>
+CreateGuiElement
+^</tool_name^\>
+^<tool_description^\>
+Creates a GUI element of a specified type.
+^</tool_description^\>
+^<tool_parameters^\>
+{"element_type": "string", "parent_path": "string?", "properties": "object?"}
+^</tool_parameters^\>
+^<tool_name^\>
+CreateInstance
+^</tool_name^\>
+^<tool_description^\>
+Creates a new instance of a specified class.
+^</tool_description^\>
+^<tool_parameters^\>
+{"class_name": "string", "properties": "object?", "parent_path": "string?"}
+^</tool_parameters^\>
+^<tool_name^\>
+CreateProximityPrompt
+^</tool_name^\>
+^<tool_description^\>
+Creates a ProximityPrompt for a part.
+^</tool_description^\>
+^<tool_parameters^\>
+{"parent_part_path": "string", "properties": "object?"}
+^</tool_parameters^\>
+^<tool_name^\>
+CreateTeam
+^</tool_name^\>
+^<tool_description^\>
+Creates a new team.
+^</tool_description^\>
+^<tool_parameters^\>
+{"team_name": "string", "team_color_brickcolor_string": "string", "auto_assignable": "boolean?"}
+^</tool_parameters^\>
+^<tool_name^\>
+CreateTextChannel
+^</tool_name^\>
+^<tool_description^\>
+Creates a new text channel.
+^</tool_description^\>
+^<tool_parameters^\>
+{"channel_name": "string", "properties": "object?"}
+^</tool_parameters^\>
+^<tool_name^\>
+FilterTextForPlayer
+^</tool_name^\>
+^<tool_description^\>
+Filters a string of text for a specific player according to Roblox community standards.
+^</tool_description^\>
+^<tool_parameters^\>
+{"text_to_filter": "string", "player_path": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+FindFirstChildMatching
+^</tool_name^\>
+^<tool_description^\>
+Finds the first child of an instance that matches the given name, optionally searching recursively.
+^</tool_description^\>
+^<tool_parameters^\>
+{"parent_path": "string", "child_name": "string", "recursive": "boolean?"}
+^</tool_parameters^\>
+^<tool_name^\>
+GetChildrenOfInstance
+^</tool_name^\>
+^<tool_description^\>
+Gets all immediate children of an instance.
+^</tool_description^\>
+^<tool_parameters^\>
+{"instance_path": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+GetDescendantsOfInstance
+^</tool_name^\>
+^<tool_description^\>
+Gets all descendants of an instance.
+^</tool_description^\>
+^<tool_parameters^\>
+{"instance_path": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+GetInstanceProperties
+^</tool_name^\>
+^<tool_description^\>
+Gets specified properties of an instance.
+^</tool_description^\>
+^<tool_parameters^\>
+{"path": "string", "property_names": "array_of_strings"}
+^</tool_parameters^\>
+^<tool_name^\>
+GetInstancesWithTag
+^</tool_name^\>
+^<tool_description^\>
+Gets all instances with a specific tag.
+^</tool_description^\>
+^<tool_parameters^\>
+{"tag_name": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+GetLightingProperty
+^</tool_name^\>
+^<tool_description^\>
+Gets a property of the Lighting service.
+^</tool_description^\>
+^<tool_parameters^\>
+{"property_name": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+GetMouseHitCFrame
+^</tool_name^\>
+^<tool_description^\>
+Gets the CFrame of the mouse hit in the 3D world.
+^</tool_description^\>
+^<tool_parameters^\>
+{"camera_path": "string?"}
+^</tool_parameters^\>
+^<tool_name^\>
+GetMousePosition
+^</tool_name^\>
+^<tool_description^\>
+Gets the current 2D position of the mouse.
+^</tool_description^\>
+^<tool_parameters^\>
+{}
+^</tool_parameters^\>
+^<tool_name^\>
+GetPlayersInTeam
+^</tool_name^\>
+^<tool_description^\>
+Gets all players in a specific team.
+^</tool_description^\>
+^<tool_parameters^\>
+{"team_path_or_name": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+GetProductInfo
+^</tool_name^\>
+^<tool_description^\>
+Gets information about a product (asset or developer product).
+^</tool_description^\>
+^<tool_parameters^\>
+{"asset_id": "number", "info_type": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+GetProperties
+^</tool_name^\>
+^<tool_description^\>
+Gets specified properties of an instance. Alias for GetInstanceProperties.
+^</tool_description^\>
+^<tool_parameters^\>
+{"path": "string", "property_names": "array_of_strings"}
+^</tool_parameters^\>
+^<tool_name^\>
+GetTeams
+^</tool_name^\>
+^<tool_description^\>
+Gets all teams in the game.
+^</tool_description^\>
+^<tool_parameters^\>
+{}
+^</tool_parameters^\>
+^<tool_name^\>
+GetTeleportData
+^</tool_name^\>
+^<tool_description^\>
+Gets teleport data if the player was recently teleported.
+^</tool_description^\>
+^<tool_parameters^\>
+{}
+^</tool_parameters^\>
+^<tool_name^\>
+GetWorkspaceProperty
+^</tool_name^\>
+^<tool_description^\>
+Gets a property of the Workspace service.
+^</tool_description^\>
+^<tool_parameters^\>
+{"property_name": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+HasTag
+^</tool_name^\>
+^<tool_description^\>
+Checks if an instance has a specific tag.
+^</tool_description^\>
+^<tool_parameters^\>
+{"instance_path": "string", "tag_name": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+IncrementData
+^</tool_name^\>
+^<tool_description^\>
+Increments a numerical value in a data store.
+^</tool_description^\>
+^<tool_parameters^\>
+{"store_name": "string", "key": "string", "increment_by": "number?"}
+^</tool_parameters^\>
+^<tool_name^\>
+InsertModel
+^</tool_name^\>
+^<tool_description^\>
+Inserts a model from the Roblox library or inventory into the workspace.
+^</tool_description^\>
+^<tool_parameters^\>
+{"query": "string", "parent_path": "string?"}
+^</tool_parameters^\>
+^<tool_name^\>
+IsKeyDown
+^</tool_name^\>
+^<tool_description^\>
+Checks if a specific key is currently held down.
+^</tool_description^\>
+^<tool_parameters^\>
+{"key_code_string": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+IsMouseButtonDown
+^</tool_name^\>
+^<tool_description^\>
+Checks if a specific mouse button is currently held down.
+^</tool_description^\>
+^<tool_parameters^\>
+{"mouse_button_string": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+KickPlayer
+^</tool_name^\>
+^<tool_description^\>
+Kicks a player from the game.
+^</tool_description^\>
+^<tool_parameters^\>
+{"player_path_or_name": "string", "kick_message": "string?"}
+^</tool_parameters^\>
+^<tool_name^\>
+LoadAssetById
+^</tool_name^\>
+^<tool_description^\>
+Loads an asset by its ID.
+^</tool_description^\>
+^<tool_parameters^\>
+{"asset_id": "number", "parent_path": "string?", "desired_name": "string?"}
+^</tool_parameters^\>
+^<tool_name^\>
+LoadData
+^</tool_name^\>
+^<tool_description^\>
+Loads data from a data store.
+^</tool_description^\>
+^<tool_parameters^\>
+{"store_name": "string", "key": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+PlaySoundId
+^</tool_name^\>
+^<tool_description^\>
+Plays a sound given its asset ID.
+^</tool_description^\>
+^<tool_parameters^\>
+{"sound_id": "string", "parent_path": "string?", "properties": "object?"}
+^</tool_parameters^\>
+^<tool_name^\>
+PromptPurchase
+^</tool_name^\>
+^<tool_description^\>
+Prompts a player to purchase an item.
+^</tool_description^\>
+^<tool_parameters^\>
+{"player_path": "string", "asset_id": "number"}
+^</tool_parameters^\>
+^<tool_name^\>
+RemoveData
+^</tool_name^\>
+^<tool_description^\>
+Removes data from a data store.
+^</tool_description^\>
+^<tool_parameters^\>
+{"store_name": "string", "key": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+RemoveTag
+^</tool_name^\>
+^<tool_description^\>
+Removes a tag from an instance.
+^</tool_description^\>
+^<tool_parameters^\>
+{"instance_path": "string", "tag_name": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+RunCode
+^</tool_name^\>
+^<tool_description^\>
+Executes a string of Luau code on the server.
+^</tool_description^\>
+^<tool_parameters^\>
+{"command": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+RunScript
+^</tool_name^\>
+^<tool_description^\>
+Creates and runs a script.
+^</tool_description^\>
+^<tool_parameters^\>
+{"parent_path": "string", "script_source": "string", "script_name": "string", "script_type": "string", "initially_disabled": "boolean?"}
+^</tool_parameters^\>
+^<tool_name^\>
+SaveData
+^</tool_name^\>
+^<tool_description^\>
+Saves data to a data store.
+^</tool_description^\>
+^<tool_parameters^\>
+{"store_name": "string", "key": "string", "data": "any"}
+^</tool_parameters^\>
+^<tool_name^\>
+SelectInstances
+^</tool_name^\>
+^<tool_description^\>
+Selects instances in the Explorer.
+^</tool_description^\>
+^<tool_parameters^\>
+{"paths": "array_of_strings"}
+^</tool_parameters^\>
+^<tool_name^\>
+SendChatMessage
+^</tool_name^\>
+^<tool_description^\>
+Sends a chat message as the server or a specific speaker.
+^</tool_description^\>
+^<tool_parameters^\>
+{"message_text": "string", "channel_name": "string?", "speaker_path": "string?"}
+^</tool_parameters^\>
+^<tool_name^\>
+SetInstanceProperties
+^</tool_name^\>
+^<tool_description^\>
+Sets properties of an instance.
+^</tool_description^\>
+^<tool_parameters^\>
+{"path": "string", "properties": "object"}
+^</tool_parameters^\>
+^<tool_name^\>
+SetLightingProperty
+^</tool_name^\>
+^<tool_description^\>
+Sets a property of the Lighting service.
+^</tool_description^\>
+^<tool_parameters^\>
+{"property_name": "string", "value": "any"}
+^</tool_parameters^\>
+^<tool_name^\>
+SetProperties
+^</tool_name^\>
+^<tool_description^\>
+Sets properties of an instance. Alias for SetInstanceProperties.
+^</tool_description^\>
+^<tool_parameters^\>
+{"path": "string", "properties": "object"}
+^</tool_parameters^\>
+^<tool_name^\>
+SetWorkspaceProperty
+^</tool_name^\>
+^<tool_description^\>
+Sets a property of the Workspace service.
+^</tool_description^\>
+^<tool_parameters^\>
+{"property_name": "string", "value": "any"}
+^</tool_parameters^\>
+^<tool_name^\>
+TeleportPlayerToPlace
+^</tool_name^\>
+^<tool_description^\>
+Teleports players to a different place.
+^</tool_description^\>
+^<tool_parameters^\>
+{"player_paths": "array_of_strings", "place_id": "number", "job_id": "string?", "teleport_data": "object?", "custom_loading_screen_gui_path": "string?"}
+^</tool_parameters^\>
+^<tool_name^\>
+TweenProperties
+^</tool_name^\>
+^<tool_description^\>
+Animates properties of an instance using TweenService.
+^</tool_description^\>
+^<tool_parameters^\>
+{"instance_path": "string", "duration": "number", "easing_style": "string", "easing_direction": "string", "properties_to_tween": "object", "repeat_count": "number?", "reverses": "boolean?", "delay_time": "number?"}
+^</tool_parameters^\>
+^<tool_name^\>
+delete_instance
+^</tool_name^\>
+^<tool_description^\>
+Deletes an instance.
+^</tool_description^\>
+^<tool_parameters^\>
+{"path": "string"}
+^</tool_parameters^\>
+^<tool_name^\>
+get_selection
+^</tool_name^\>
+^<tool_description^\>
+Gets the current selection in the Explorer.
+^</tool_description^\>
+^<tool_parameters^\>
+{}
+^</tool_parameters^\>
 {{ range .Tools }}
 ^<tool_name^\>
 {{ .Name }}


### PR DESCRIPTION
This commit fixes a critical bug in `setup_phi4_fc_model.bat` where the script would delete its own source Modelfile (`phi4_fc_ollama.Modelfile`) before attempting to copy it.

The variable `MODFILE_NAME` is set to `phi4_fc_ollama.Modelfile`. The script previously had a "Clean up old Modelfile" section that would delete `!MODFILE_NAME!`. This made the subsequent step (copying `phi4_fc_ollama.Modelfile` to `!MODFILE_NAME!`) fail because the source file would have been deleted.

The fix involves removing the entire "Clean up old Modelfile" section. The `COPY /Y` command, which is used to prepare the Modelfile for the `ollama create` command, will handle overwriting the destination if it already exists, making the explicit deletion of the source file unnecessary and erroneous in this context.